### PR TITLE
Fix error message in `Mark.from_json`

### DIFF
--- a/prosemirror/model/mark.py
+++ b/prosemirror/model/mark.py
@@ -56,9 +56,10 @@ class Mark:
             json_data = json.loads(json_data)
         if not json_data:
             raise ValueError("Invalid input for Mark.fromJSON")
-        type = schema.marks.get(json_data["type"])
+        name = json_data["type"]
+        type = schema.marks.get(name)
         if not type:
-            raise ValueError(f"There is not mark type {type} in this schema")
+            raise ValueError(f"There is no mark type {name} in this schema")
         return type.create(json_data.get("attrs"))
 
     @classmethod


### PR DESCRIPTION
Before:
```pycon
>>> from prosemirror.model import Mark
>>> from prosemirror.test_builder import test_schema
>>> Mark.from_json(test_schema, { "type": "foobar" })
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/calumsmith/Documents/Code/prosemirror-py/prosemirror/model/mark.py", line 61, in from_json
    raise ValueError(f"There is not mark type {type} in this schema")
ValueError: There is not mark type None in this schema
```

After:
```pycon
>>> from prosemirror.model import Mark
>>> from prosemirror.test_builder import test_schema
>>> Mark.from_json(test_schema, { "type": "foobar" })
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/calumsmith/Documents/Code/prosemirror-py/prosemirror/model/mark.py", line 62, in from_json
    raise ValueError(f"There is no mark type {name} in this schema")
ValueError: There is no mark type foobar in this schema
```