### PR TITLE
Escape text nodes when serializing to html

### DIFF
--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -1,13 +1,10 @@
+import html
 from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from . import Fragment, Mark, Node, Schema
 
 
 HTMLNode = Union["Element", str]
-
-
-def escape_attr_value(s: str) -> str:
-    return s.replace('"', '\\"')
 
 
 class DocumentFragment:
@@ -46,7 +43,7 @@ class Element(DocumentFragment):
 
     def __str__(self):
         attrs_str = " ".join(
-            [f'{k}="{escape_attr_value(v)}"' for k, v in self.attrs.items()]
+            [f'{k}="{html.escape(v)}"' for k, v in self.attrs.items()]
         )
         open_tag_str = " ".join([s for s in [self.name, attrs_str] if s])
         if self.name in self.self_closing_elements:
@@ -144,7 +141,7 @@ class DOMSerializer:
         cls, structure: HTMLOutputSpec
     ) -> Tuple[HTMLNode, Optional[Element]]:
         if isinstance(structure, str):
-            return structure, None
+            return html.escape(structure), None
         if isinstance(structure, Element):
             return structure, None
         tag_name = structure[0]

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -42,9 +42,7 @@ class Element(DocumentFragment):
         super().__init__(children)
 
     def __str__(self):
-        attrs_str = " ".join(
-            [f'{k}="{html.escape(v)}"' for k, v in self.attrs.items()]
-        )
+        attrs_str = " ".join([f'{k}="{html.escape(v)}"' for k, v in self.attrs.items()])
         open_tag_str = " ".join([s for s in [self.name, attrs_str] if s])
         if self.name in self.self_closing_elements:
             assert not self.children, "self-closing elements should not have children"

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -150,3 +150,10 @@ def test_parser(doc, html, desc):
 )
 def test_serializer(serializer, doc, expect, desc):
     assert str(serializer.serialize_fragment(doc.content)) == expect, desc
+
+
+def test_html_is_escaped():
+    assert (
+        str(serializer.serialize_node(schema.text("<b>bold &</b>")))
+        == "&lt;b&gt;bold &amp;&lt;/b&gt;"
+    )


### PR DESCRIPTION
Without this DOMSerializer is unusable, since any HTML-like text will be included verbatim in the HTML output.