### PR TITLE
Port prosemirror-transform changes up to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides Python implementations of the following
 [ProseMirror](https://prosemirror.net/) packages:
 
 - [`prosemirror-model`](https://github.com/ProseMirror/prosemirror-model) version 1.18.1
-- [`prosemirror-transform`](https://github.com/ProseMirror/prosemirror-transform) version 1.6.0
+- [`prosemirror-transform`](https://github.com/ProseMirror/prosemirror-transform) version 1.7.1
 - [`prosemirror-test-builder`](https://github.com/ProseMirror/prosemirror-test-builder)
 - [`prosemirror-schema-basic`](https://github.com/ProseMirror/prosemirror-schema-basic) version 1.1.2
 - [`prosemirror-schema-list`](https://github.com/ProseMirror/prosemirror-schema-list)

--- a/prosemirror/transform/replace.py
+++ b/prosemirror/transform/replace.py
@@ -116,8 +116,22 @@ class Fitter:
         return None
 
     def find_fittable(self) -> Optional[_Fittable]:
+        start_depth = self.unplaced.open_start
+        cur = self.unplaced.content
+        open_end = self.unplaced.open_end
+        for d in range(start_depth):
+            node = cur.first_child
+            if cur.child_count > 1:
+                open_end = 0
+            if node.type.spec.get("isolating") and open_end <= d:
+                start_depth = d
+                break
+            cur = node.content
+
         for pass_ in [1, 2]:
-            for slice_depth in range(self.unplaced.open_start, -1, -1):
+            for slice_depth in range(
+                start_depth if pass_ == 1 else self.unplaced.open_start, -1, -1
+            ):
                 if slice_depth:
                     parent = content_at(
                         self.unplaced.content, slice_depth - 1

--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -1,11 +1,11 @@
 from typing import Union
 
-from prosemirror.model import Fragment, MarkType, Node, NodeType, Slice
+from prosemirror.model import Fragment, Mark, MarkType, Node, NodeType, Slice
 
 from . import replace, structure
 from .attr_step import AttrStep
 from .map import Mapping
-from .mark_step import AddMarkStep, RemoveMarkStep
+from .mark_step import AddMarkStep, AddNodeMarkStep, RemoveMarkStep, RemoveNodeMarkStep
 from .replace import close_fragment, covered_depths, fits_trivially, replace_step
 from .replace_step import ReplaceAroundStep, ReplaceStep
 from .structure import can_change_type, insert_point
@@ -459,6 +459,19 @@ class Transform:
 
     def set_node_attribute(self, pos, attr, value):
         return self.step(AttrStep(pos, attr, value))
+
+    def add_node_mark(self, pos, mark):
+        return self.step(AddNodeMarkStep(pos, mark))
+
+    def remove_node_mark(self, pos, mark):
+        if not isinstance(mark, Mark):
+            node = self.doc.node_at(pos)
+            if not node:
+                raise ValueError("No node at position " + pos)
+            mark = mark.is_in_set(node.marks)
+            if not mark:
+                return self
+        return self.step(RemoveNodeMarkStep(pos, mark))
 
     def split(self, pos, depth=None, types_after=None):
         if depth is None:

--- a/tests/prosemirror_transform/tests/test_trans.py
+++ b/tests/prosemirror_transform/tests/test_trans.py
@@ -1051,3 +1051,37 @@ def test_delete_range(doc, expect, test_transform):
         doc.tag.get("a"), doc.tag.get("b") or doc.tag.get("a")
     )
     test_transform(tr, expect)
+
+
+@pytest.mark.parametrize(
+    "doc,mark,expect",
+    [
+        # adds a mark
+        (doc(p("<a>", img())), schema.mark("em"), doc(p("<a>", em(img())))),
+        # doesn't duplicate a mark
+        (doc(p("<a>", em(img()))), schema.mark("em"), doc(p("<a>", em(img())))),
+        # replaces a mark
+        (
+            doc(p("<a>", a(img()))),
+            schema.mark("link", {"href": "x"}),
+            doc(p("<a>", a({"href": "x"}, img()))),
+        ),
+    ],
+)
+def test_add_node_mark(doc, mark, expect, test_transform):
+    test_transform(Transform(doc).add_node_mark(doc.tag["a"], mark), expect)
+
+
+@pytest.mark.parametrize(
+    "doc,mark,expect",
+    [
+        # removes a mark
+        (doc(p("<a>", em(img()))), schema.mark("em"), doc(p("<a>", img()))),
+        # doesn't do anything when there is no mark
+        (doc(p("<a>", img())), schema.mark("em"), doc(p("<a>", img()))),
+        # can remove a mark from multiple marks
+        (doc(p("<a>", em(a(img())))), schema.mark("em"), doc(p("<a>", a(img())))),
+    ],
+)
+def test_remove_node_mark(doc, mark, expect, test_transform):
+    test_transform(Transform(doc).remove_node_mark(doc.tag["a"], mark), expect)


### PR DESCRIPTION
Upstream changes: https://github.com/ProseMirror/prosemirror-transform/compare/1.6.0...1.7.1

In particular, this adds AddNodeMarkStep and RemoveNodeMarkStep, and a fix to replace_step.

The regression in https://github.com/ProseMirror/prosemirror-transform/commit/aadd1026938760055ef60d6d7ca009d7e2d41659 came about during the TypeScript migration so it doesn't need any changes here.