### PR TITLE
Drop support for Python < 3.10 and add additional Ruff rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/example.py
+++ b/example.py
@@ -75,10 +75,10 @@ basic_spec = {
             "parseDOM": [{"tag": "a[href]"}],
         },
         "em": {
-            "parseDOM": [{"tag": "i"}, {"tag": "em"}, {"style": "font-style=italic"}]
+            "parseDOM": [{"tag": "i"}, {"tag": "em"}, {"style": "font-style=italic"}],
         },
         "strong": {
-            "parseDOM": [{"tag": "strong"}, {"tag": "b"}, {"style": "font-weight"}]
+            "parseDOM": [{"tag": "strong"}, {"tag": "b"}, {"style": "font-weight"}],
         },
         "code": {"parseDOM": [{"tag": "code"}]},
     },

--- a/prosemirror/model/content.py
+++ b/prosemirror/model/content.py
@@ -3,14 +3,11 @@ from functools import cmp_to_key, reduce
 from typing import (
     TYPE_CHECKING,
     ClassVar,
-    Dict,
-    List,
     Literal,
     NamedTuple,
     NoReturn,
     Optional,
     TypedDict,
-    Union,
     cast,
 )
 
@@ -32,11 +29,9 @@ class MatchEdge:
 
 class WrapCacheEntry:
     target: "NodeType"
-    computed: Optional[List["NodeType"]]
+    computed: list["NodeType"] | None
 
-    def __init__(
-        self, target: "NodeType", computed: Optional[List["NodeType"]]
-    ) -> None:
+    def __init__(self, target: "NodeType", computed: list["NodeType"] | None) -> None:
         self.target = target
         self.computed = computed
 
@@ -57,8 +52,8 @@ class ContentMatch:
 
     empty: ClassVar["ContentMatch"]
     valid_end: bool
-    next: List[MatchEdge]
-    wrap_cache: List[WrapCacheEntry]
+    next: list[MatchEdge]
+    wrap_cache: list[WrapCacheEntry]
 
     def __init__(self, valid_end: bool) -> None:
         self.valid_end = valid_end
@@ -66,7 +61,7 @@ class ContentMatch:
         self.wrap_cache = []
 
     @classmethod
-    def parse(cls, string: str, node_types: Dict[str, "NodeType"]) -> "ContentMatch":
+    def parse(cls, string: str, node_types: dict[str, "NodeType"]) -> "ContentMatch":
         stream = TokenStream(string, node_types)
         if stream.next() is None:
             return ContentMatch.empty
@@ -84,11 +79,11 @@ class ContentMatch:
         return None
 
     def match_fragment(
-        self, frag: Fragment, start: int = 0, end: Optional[int] = None
+        self, frag: Fragment, start: int = 0, end: int | None = None
     ) -> Optional["ContentMatch"]:
         if end is None:
             end = frag.child_count
-        cur: Optional["ContentMatch"] = self
+        cur: "ContentMatch" | None = self
         i = start
         while cur and i < end:
             cur = cur.match_type(frag.child(i).type)
@@ -116,10 +111,10 @@ class ContentMatch:
 
     def fill_before(
         self, after: Fragment, to_end: bool = False, start_index: int = 0
-    ) -> Optional[Fragment]:
+    ) -> Fragment | None:
         seen = [self]
 
-        def search(match: ContentMatch, types: List["NodeType"]) -> Optional[Fragment]:
+        def search(match: ContentMatch, types: list["NodeType"]) -> Fragment | None:
             nonlocal seen
             finished = match.match_fragment(after, start_index)
             if finished and (not to_end or finished.valid_end):
@@ -138,7 +133,7 @@ class ContentMatch:
 
         return search(self, [])
 
-    def find_wrapping(self, target: "NodeType") -> Optional[List["NodeType"]]:
+    def find_wrapping(self, target: "NodeType") -> list["NodeType"] | None:
         for entry in self.wrap_cache:
             if entry.target.name == target.name:
                 return entry.computed
@@ -146,9 +141,9 @@ class ContentMatch:
         self.wrap_cache.append(WrapCacheEntry(target, computed))
         return computed
 
-    def compute_wrapping(self, target: "NodeType") -> Optional[List["NodeType"]]:
+    def compute_wrapping(self, target: "NodeType") -> list["NodeType"] | None:
         seen = {}
-        active: List[Active] = [{"match": self, "type": None, "via": None}]
+        active: list[Active] = [{"match": self, "type": None, "via": None}]
         while len(active):
             current = active.pop(0)
             match = current["match"]
@@ -217,23 +212,23 @@ TOKEN_REGEX = re.compile(r"\w+|\W")
 
 
 class TokenStream:
-    inline: Optional[bool]
-    tokens: List[str]
+    inline: bool | None
+    tokens: list[str]
 
-    def __init__(self, string: str, node_types: Dict[str, "NodeType"]) -> None:
+    def __init__(self, string: str, node_types: dict[str, "NodeType"]) -> None:
         self.string = string
         self.node_types = node_types
         self.inline = None
         self.pos = 0
         self.tokens = [i for i in TOKEN_REGEX.findall(string) if i.strip()]
 
-    def next(self) -> Optional[str]:
+    def next(self) -> str | None:
         try:
             return self.tokens[self.pos]
         except IndexError:
             return None
 
-    def eat(self, tok: str) -> Union[int, bool]:
+    def eat(self, tok: str) -> int | bool:
         if self.next() == tok:
             pos = self.pos
             self.pos += 1
@@ -247,12 +242,12 @@ class TokenStream:
 
 class ChoiceExpr(TypedDict):
     type: Literal["choice"]
-    exprs: List["Expr"]
+    exprs: list["Expr"]
 
 
 class SeqExpr(TypedDict):
     type: Literal["seq"]
-    exprs: List["Expr"]
+    exprs: list["Expr"]
 
 
 class PlusExpr(TypedDict):
@@ -282,7 +277,7 @@ class NameExpr(TypedDict):
     value: "NodeType"
 
 
-Expr = Union[ChoiceExpr, SeqExpr, PlusExpr, StarExpr, OptExpr, RangeExpr, NameExpr]
+Expr = ChoiceExpr | SeqExpr | PlusExpr | StarExpr | OptExpr | RangeExpr | NameExpr
 
 
 def parse_expr(stream: TokenStream) -> Expr:
@@ -350,7 +345,7 @@ def parse_expr_range(stream: TokenStream, expr: Expr) -> Expr:
     return {"type": "range", "min": min_, "max": max_, "expr": expr}
 
 
-def resolve_name(stream: TokenStream, name: str) -> List["NodeType"]:
+def resolve_name(stream: TokenStream, name: str) -> list["NodeType"]:
     types = stream.node_types
     type = types.get(name)
     if type:
@@ -395,13 +390,13 @@ def parse_expr_atom(
 
 class Edge(TypedDict):
     term: Optional["NodeType"]
-    to: Optional[int]
+    to: int | None
 
 
 def nfa(
     expr: Expr,
-) -> List[List[Edge]]:
-    nfa_: List[List[Edge]] = [[]]
+) -> list[list[Edge]]:
+    nfa_: list[list[Edge]] = [[]]
 
     def node() -> int:
         nonlocal nfa_
@@ -409,24 +404,24 @@ def nfa(
         return len(nfa_) - 1
 
     def edge(
-        from_: int, to: Optional[int] = None, term: Optional["NodeType"] = None
+        from_: int, to: int | None = None, term: Optional["NodeType"] = None
     ) -> Edge:
         nonlocal nfa_
         edge: Edge = {"term": term, "to": to}
         nfa_[from_].append(edge)
         return edge
 
-    def connect(edges: List[Edge], to: int) -> None:
+    def connect(edges: list[Edge], to: int) -> None:
         for edge in edges:
             edge["to"] = to
 
-    def compile(expr: Expr, from_: int) -> List[Edge]:
+    def compile(expr: Expr, from_: int) -> list[Edge]:
         if expr["type"] == "choice":
             return list(
                 reduce(
                     lambda out, expr: [*out, *compile(expr, from_)],
                     expr["exprs"],
-                    cast(List[Edge], []),
+                    cast(list[Edge], []),
                 )
             )
         elif expr["type"] == "seq":
@@ -477,9 +472,9 @@ def cmp(a: int, b: int) -> int:
 
 
 def null_from(
-    nfa: List[List[Edge]],
+    nfa: list[list[Edge]],
     node: int,
-) -> List[int]:
+) -> list[int]:
     result = []
 
     def scan(n: int) -> None:
@@ -499,21 +494,21 @@ def null_from(
 
 class DFAState(NamedTuple):
     state: "NodeType"
-    next: List[int]
+    next: list[int]
 
 
-def dfa(nfa: List[List[Edge]]) -> ContentMatch:
+def dfa(nfa: list[list[Edge]]) -> ContentMatch:
     labeled = {}
 
-    def explore(states: List[int]) -> ContentMatch:
+    def explore(states: list[int]) -> ContentMatch:
         nonlocal labeled
-        out: List[DFAState] = []
+        out: list[DFAState] = []
         for node in states:
             for item in nfa[node]:
                 term, to = item.get("term"), item.get("to")
                 if not term:
                     continue
-                set: Optional[List[int]] = None
+                set: list[int] | None = None
                 for t in out:
                     if t[0] == term:
                         set = t[1]

--- a/prosemirror/model/content.py
+++ b/prosemirror/model/content.py
@@ -447,14 +447,14 @@ def nfa(
             return [edge(from_), *compile(expr["expr"], from_)]
         elif expr["type"] == "range":
             cur = from_
-            for i in range(expr["min"]):
+            for _i in range(expr["min"]):
                 next = node()
                 connect(compile(expr["expr"], cur), next)
                 cur = next
             if expr["max"] == -1:
                 connect(compile(expr["expr"], cur), cur)
             else:
-                for i in range(expr["min"], expr["max"]):
+                for _i in range(expr["min"], expr["max"]):
                     next = node()
                     edge(cur, next)
                     connect(compile(expr["expr"], cur), next)

--- a/prosemirror/model/content.py
+++ b/prosemirror/model/content.py
@@ -79,7 +79,10 @@ class ContentMatch:
         return None
 
     def match_fragment(
-        self, frag: Fragment, start: int = 0, end: int | None = None
+        self,
+        frag: Fragment,
+        start: int = 0,
+        end: int | None = None,
     ) -> Optional["ContentMatch"]:
         if end is None:
             end = frag.child_count
@@ -110,7 +113,10 @@ class ContentMatch:
         return False
 
     def fill_before(
-        self, after: Fragment, to_end: bool = False, start_index: int = 0
+        self,
+        after: Fragment,
+        to_end: bool = False,
+        start_index: int = 0,
     ) -> Fragment | None:
         seen = [self]
 
@@ -403,7 +409,9 @@ def nfa(
         return len(nfa_) - 1
 
     def edge(
-        from_: int, to: int | None = None, term: Optional["NodeType"] = None
+        from_: int,
+        to: int | None = None,
+        term: Optional["NodeType"] = None,
     ) -> Edge:
         nonlocal nfa_
         edge: Edge = {"term": term, "to": to}
@@ -421,7 +429,7 @@ def nfa(
                     lambda out, expr: [*out, *compile(expr, from_)],
                     expr["exprs"],
                     cast(list[Edge], []),
-                )
+                ),
             )
         elif expr["type"] == "seq":
             i = 0
@@ -524,7 +532,7 @@ def dfa(nfa: list[list[Edge]]) -> ContentMatch:
             states = out[i][1]
             find_by_key = ",".join(str(s) for s in states)
             state.next.append(
-                MatchEdge(out[i][0], labeled.get(find_by_key) or explore(states))
+                MatchEdge(out[i][0], labeled.get(find_by_key) or explore(states)),
             )
         return state
 
@@ -549,6 +557,6 @@ def check_for_dead_ends(match: ContentMatch, stream: TokenStream) -> None:
         if dead:
             stream.err(
                 f'Only non-generatable nodes ({", ".join(nodes)}) in a required '
-                "position (see https://prosemirror.net/docs/guide/#generatable)"
+                "position (see https://prosemirror.net/docs/guide/#generatable)",
             )
         i += 1

--- a/prosemirror/model/content.py
+++ b/prosemirror/model/content.py
@@ -336,10 +336,7 @@ def parse_expr_range(stream: TokenStream, expr: Expr) -> Expr:
     min_ = parse_num(stream)
     max_ = min_
     if stream.eat(","):
-        if stream.next() != "}":
-            max_ = parse_num(stream)
-        else:
-            max_ = -1
+        max_ = parse_num(stream) if stream.next() != "}" else -1
     if not stream.eat("}"):
         stream.err("Unclosed braced range")
     return {"type": "range", "min": min_, "max": max_, "expr": expr}

--- a/prosemirror/model/content.py
+++ b/prosemirror/model/content.py
@@ -176,7 +176,8 @@ class ContentMatch:
 
     def edge(self, n: int) -> MatchEdge:
         if n >= len(self.next):
-            raise ValueError(f"There's no {n}th edge in this content match")
+            msg = f"There's no {n}th edge in this content match"
+            raise ValueError(msg)
         return self.next[n]
 
     def __str__(self) -> str:
@@ -237,7 +238,8 @@ class TokenStream:
             return False
 
     def err(self, str: str) -> NoReturn:
-        raise SyntaxError(f'{str} (in content expression) "{self.string}"')
+        msg = f'{str} (in content expression) "{self.string}"'
+        raise SyntaxError(msg)
 
 
 class ChoiceExpr(TypedDict):

--- a/prosemirror/model/diff.py
+++ b/prosemirror/model/diff.py
@@ -36,7 +36,9 @@ def find_diff_start(a: "Fragment", b: "Fragment", pos: int) -> int | None:
                     (
                         index_a
                         for ((index_a, char_a), (_, char_b)) in zip(
-                            enumerate(child_a.text), enumerate(child_b.text)
+                            enumerate(child_a.text),
+                            enumerate(child_b.text),
+                            strict=True,
                         )
                         if char_a != char_b
                     ),

--- a/prosemirror/model/diff.py
+++ b/prosemirror/model/diff.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from prosemirror.utils import text_length
 
@@ -13,7 +13,7 @@ class Diff(TypedDict):
     b: int
 
 
-def find_diff_start(a: "Fragment", b: "Fragment", pos: int) -> Optional[int]:
+def find_diff_start(a: "Fragment", b: "Fragment", pos: int) -> int | None:
     i = 0
     while True:
         if a.child_count == i or b.child_count == i:
@@ -52,9 +52,7 @@ def find_diff_start(a: "Fragment", b: "Fragment", pos: int) -> Optional[int]:
         i += 1
 
 
-def find_diff_end(
-    a: "Fragment", b: "Fragment", pos_a: int, pos_b: int
-) -> Optional[Diff]:
+def find_diff_end(a: "Fragment", b: "Fragment", pos_a: int, pos_b: int) -> Diff | None:
     i_a, i_b = a.child_count, b.child_count
     while True:
         if i_a == 0 or i_b == 0:

--- a/prosemirror/model/diff.py
+++ b/prosemirror/model/diff.py
@@ -94,7 +94,10 @@ def find_diff_end(a: "Fragment", b: "Fragment", pos_a: int, pos_b: int) -> Diff 
 
         if child_a.content.size or child_b.content.size:
             inner = find_diff_end(
-                child_a.content, child_b.content, pos_a - 1, pos_b - 1
+                child_a.content,
+                child_b.content,
+                pos_a - 1,
+                pos_b - 1,
             )
             if inner:
                 return inner

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -1,13 +1,9 @@
+from collections.abc import Callable, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
-    Dict,
-    Iterable,
-    List,
     Optional,
-    Sequence,
     Union,
     cast,
 )
@@ -21,16 +17,16 @@ if TYPE_CHECKING:
     from .node import Node, TextNode
 
 
-def retIndex(index: int, offset: int) -> Dict[str, int]:
+def retIndex(index: int, offset: int) -> dict[str, int]:
     return {"index": index, "offset": offset}
 
 
 class Fragment:
     empty: ClassVar["Fragment"]
-    content: List["Node"]
+    content: list["Node"]
     size: int
 
-    def __init__(self, content: List["Node"], size: Optional[int] = None) -> None:
+    def __init__(self, content: list["Node"], size: int | None = None) -> None:
         self.content = content
         self.size = size if size is not None else sum(c.node_size for c in content)
 
@@ -38,7 +34,7 @@ class Fragment:
         self,
         from_: int,
         to: int,
-        f: Callable[["Node", int, Optional["Node"], int], Optional[bool]],
+        f: Callable[["Node", int, Optional["Node"], int], bool | None],
         node_start: int = 0,
         parent: Optional["Node"] = None,
     ) -> None:
@@ -63,7 +59,7 @@ class Fragment:
             i += 1
 
     def descendants(
-        self, f: Callable[["Node", int, Optional["Node"], int], Optional[bool]]
+        self, f: Callable[["Node", int, Optional["Node"], int], bool | None]
     ) -> None:
         self.nodes_between(0, self.size, f)
 
@@ -72,7 +68,7 @@ class Fragment:
         from_: int,
         to: int,
         block_separator: str = "",
-        leaf_text: Union[Callable[["Node"], str], str] = "",
+        leaf_text: Callable[["Node"], str] | str = "",
     ) -> str:
         text = []
         separated = True
@@ -120,12 +116,12 @@ class Fragment:
             i += 1
         return Fragment(content, self.size + other.size)
 
-    def cut(self, from_: int, to: Optional[int] = None) -> "Fragment":
+    def cut(self, from_: int, to: int | None = None) -> "Fragment":
         if to is None:
             to = self.size
         if from_ == 0 and to == self.size:
             return self
-        result: List["Node"] = []
+        result: list["Node"] = []
         size = 0
         if to <= from_:
             return Fragment(result, size)
@@ -150,7 +146,7 @@ class Fragment:
             i += 1
         return Fragment(result, size)
 
-    def cut_by_index(self, from_: int, to: Optional[int] = None) -> "Fragment":
+    def cut_by_index(self, from_: int, to: int | None = None) -> "Fragment":
         if from_ == to:
             return Fragment.empty
         if from_ == 0 and to == len(self.content):
@@ -207,7 +203,7 @@ class Fragment:
             p += child.node_size
             i += 1
 
-    def find_diff_start(self, other: "Fragment", pos: int = 0) -> Optional[int]:
+    def find_diff_start(self, other: "Fragment", pos: int = 0) -> int | None:
         from .diff import find_diff_start
 
         return find_diff_start(self, other, pos)
@@ -215,8 +211,8 @@ class Fragment:
     def find_diff_end(
         self,
         other: "Fragment",
-        pos: Optional[int] = None,
-        other_pos: Optional[int] = None,
+        pos: int | None = None,
+        other_pos: int | None = None,
     ) -> Optional["Diff"]:
         from .diff import find_diff_end
 
@@ -226,7 +222,7 @@ class Fragment:
             other_pos = other.size
         return find_diff_end(self, other, pos, other_pos)
 
-    def find_index(self, pos: int, round: int = -1) -> Dict[str, int]:
+    def find_index(self, pos: int, round: int = -1) -> dict[str, int]:
         if pos == 0:
             return retIndex(0, pos)
         if pos == self.size:
@@ -245,7 +241,7 @@ class Fragment:
             i += 1
             cur_pos = end
 
-    def to_json(self) -> Optional[JSONList]:
+    def to_json(self) -> JSONList | None:
         if self.content:
             return [item.to_json() for item in self.content]
         return None
@@ -266,10 +262,10 @@ class Fragment:
         return cls([schema.node_from_json(item) for item in value])
 
     @classmethod
-    def from_array(cls, array: List["Node"]) -> "Fragment":
+    def from_array(cls, array: list["Node"]) -> "Fragment":
         if not array:
             return cls.empty
-        joined: Optional[List["Node"]] = None
+        joined: list["Node"] | None = None
         size = 0
         for i in range(len(array)):
             node = array[i]

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -171,7 +171,7 @@ class Fragment:
     def eq(self, other: "Fragment") -> bool:
         if len(self.content) != len(other.content):
             return False
-        return all(a.eq(b) for (a, b) in zip(self.content, other.content))
+        return all(a.eq(b) for (a, b) in zip(self.content, other.content, strict=True))
 
     @property
     def first_child(self) -> Optional["Node"]:

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -106,7 +106,8 @@ class Fragment:
             self.content.copy(),
             0,
         )
-        assert last is not None and first is not None
+        assert last is not None
+        assert first is not None
         if pm_node.is_text(last) and last.same_markup(first):
             assert isinstance(first, pm_node.TextNode)
             content[len(content) - 1] = last.with_text(last.text + first.text)

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -59,7 +59,8 @@ class Fragment:
             i += 1
 
     def descendants(
-        self, f: Callable[["Node", int, Optional["Node"], int], bool | None]
+        self,
+        f: Callable[["Node", int, Optional["Node"], int], bool | None],
     ) -> None:
         self.nodes_between(0, self.size, f)
 
@@ -74,7 +75,10 @@ class Fragment:
         separated = True
 
         def iteratee(
-            node: "Node", pos: int, _parent: Optional["Node"], _to: int
+            node: "Node",
+            pos: int,
+            _parent: Optional["Node"],
+            _to: int,
         ) -> None:
             nonlocal text
             nonlocal separated
@@ -134,7 +138,8 @@ class Fragment:
                 if pos < from_ or end > to:
                     if pm_node.is_text(child):
                         child = child.cut(
-                            max(0, from_ - pos), min(text_length(child.text), to - pos)
+                            max(0, from_ - pos),
+                            min(text_length(child.text), to - pos),
                         )
                     else:
                         child = child.cut(
@@ -285,7 +290,8 @@ class Fragment:
 
     @classmethod
     def from_(
-        cls, nodes: Union["Fragment", "Node", Sequence["Node"], None]
+        cls,
+        nodes: Union["Fragment", "Node", Sequence["Node"], None],
     ) -> "Fragment":
         if not nodes:
             return cls.empty

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -8,7 +8,7 @@ from typing import (
     cast,
 )
 
-from prosemirror.utils import JSONList, text_length
+from prosemirror.utils import JSON, JSONList, text_length
 
 if TYPE_CHECKING:
     from prosemirror.model.schema import Schema
@@ -254,7 +254,7 @@ class Fragment:
         return None
 
     @classmethod
-    def from_json(cls, schema: "Schema[Any, Any]", value: Any) -> "Fragment":
+    def from_json(cls, schema: "Schema[Any, Any]", value: JSON) -> "Fragment":
         if not value:
             return cls.empty
 

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from .node import Node, TextNode
 
 
-def retIndex(index: int, offset: int) -> dict[str, int]:
+def ret_index(index: int, offset: int) -> dict[str, int]:
     return {"index": index, "offset": offset}
 
 
@@ -230,9 +230,9 @@ class Fragment:
 
     def find_index(self, pos: int, round: int = -1) -> dict[str, int]:
         if pos == 0:
-            return retIndex(0, pos)
+            return ret_index(0, pos)
         if pos == self.size:
-            return retIndex(len(self.content), pos)
+            return ret_index(len(self.content), pos)
         if pos > self.size or pos < 0:
             msg = f"Position {pos} outside of fragment ({self})"
             raise ValueError(msg)
@@ -243,8 +243,8 @@ class Fragment:
             end = cur_pos + cur.node_size
             if end >= pos:
                 if end == pos or round > 0:
-                    return retIndex(i + 1, end)
-                return retIndex(i, cur_pos)
+                    return ret_index(i + 1, end)
+                return ret_index(i, cur_pos)
             i += 1
             cur_pos = end
 

--- a/prosemirror/model/fragment.py
+++ b/prosemirror/model/fragment.py
@@ -229,7 +229,8 @@ class Fragment:
         if pos == self.size:
             return retIndex(len(self.content), pos)
         if pos > self.size or pos < 0:
-            raise ValueError(f"Position {pos} outside of fragment ({self})")
+            msg = f"Position {pos} outside of fragment ({self})"
+            raise ValueError(msg)
         i = 0
         cur_pos = 0
         while True:
@@ -258,7 +259,8 @@ class Fragment:
             value = json.loads(value)
 
         if not isinstance(value, list):
-            raise ValueError("Invalid input for Fragment.from_json")
+            msg = "Invalid input for Fragment.from_json"
+            raise ValueError(msg)
 
         return cls([schema.node_from_json(item) for item in value])
 
@@ -293,7 +295,8 @@ class Fragment:
             return cls.from_array(list(nodes))
         if hasattr(nodes, "attrs"):
             return cls([nodes], nodes.node_size)
-        raise ValueError(f"cannot convert {nodes!r} to a fragment")
+        msg = f"cannot convert {nodes!r} to a fragment"
+        raise ValueError(msg)
 
     def to_string_inner(self) -> str:
         return ", ".join([str(i) for i in self.content])

--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -985,7 +985,7 @@ class ParseContext:
 
                 if (
                     default is not None
-                    and default.is_text_block
+                    and default.is_textblock
                     and default.default_attrs
                 ):
                     return default
@@ -993,7 +993,7 @@ class ParseContext:
                 d -= 1
 
         for type_ in self.parser.schema.nodes.values():
-            if type_.is_text_block and type_.default_attrs:
+            if type_.is_textblock and type_.default_attrs:
                 return type_
 
         return None

--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -108,7 +108,9 @@ class DOMParser:
         ])
 
     def parse(
-        self, dom_: lxml.html.HtmlElement, options: ParseOptions | None = None
+        self,
+        dom_: lxml.html.HtmlElement,
+        options: ParseOptions | None = None,
     ) -> Node:
         if options is None:
             options = ParseOptions()
@@ -144,7 +146,10 @@ class DOMParser:
         return Slice.max_open(cast(Fragment, context.finish()))
 
     def match_tag(
-        self, dom_: DOMNode, context: "ParseContext", after: ParseRule | None = None
+        self,
+        dom_: DOMNode,
+        context: "ParseContext",
+        after: ParseRule | None = None,
     ) -> ParseRule | None:
         try:
             i = self._tags.index(after) + 1 if after is not None else 0
@@ -254,7 +259,8 @@ class DOMParser:
     def from_schema(cls, schema: Schema[Any, Any]) -> "DOMParser":
         if "dom_parser" not in schema.cached:
             schema.cached["dom_parser"] = DOMParser(
-                schema, DOMParser.schema_rules(schema)
+                schema,
+                DOMParser.schema_rules(schema),
             )
 
         return cast("DOMParser", schema.cached["dom_parser"])
@@ -313,7 +319,9 @@ OPT_OPEN_LEFT = 4
 
 
 def ws_options_for(
-    _type: NodeType | None, preserve_whitespace: WSType, base: int
+    _type: NodeType | None,
+    preserve_whitespace: WSType,
+    base: int,
 ) -> int:
     if preserve_whitespace is not None:
         return (OPT_PRESERVE_WS if preserve_whitespace else 0) | (
@@ -418,7 +426,7 @@ class NodeContext:
         content = Fragment.from_(self.content)
         if not open_end and self.match is not None:
             content = content.append(
-                cast(Fragment, self.match.fill_before(Fragment.empty, True))
+                cast(Fragment, self.match.fill_before(Fragment.empty, True)),
             )
 
         return (
@@ -486,7 +494,13 @@ class ParseContext:
             )
         elif is_open:
             top_context = NodeContext(
-                None, None, Mark.none, Mark.none, True, None, top_options
+                None,
+                None,
+                Mark.none,
+                Mark.none,
+                True,
+                None,
+                top_options,
             )
         else:
             top_context = NodeContext(
@@ -565,7 +579,8 @@ class ParseContext:
                         or (
                             node_before.is_text
                             and re.search(
-                                r"[ \t\r\n\u000c]$", cast(TextNode, node_before).text
+                                r"[ \t\r\n\u000c]$",
+                                cast(TextNode, node_before).text,
                             )
                             is not None
                         )
@@ -632,7 +647,9 @@ class ParseContext:
 
         else:
             self.add_element_by_rule(
-                dom_, rule, rule_id if rule.consuming is False else None
+                dom_,
+                rule,
+                rule_id if rule.consuming is False else None,
             )
 
     def leaf_fallback(self, dom_: DOMNode) -> None:
@@ -678,7 +695,10 @@ class ParseContext:
         return add, remove
 
     def add_element_by_rule(
-        self, dom_: DOMNode, rule: ParseRule, continue_after: ParseRule | None = None
+        self,
+        dom_: DOMNode,
+        rule: ParseRule,
+        continue_after: ParseRule | None = None,
     ) -> None:
         sync: bool = False
         mark: Mark | None = None
@@ -704,7 +724,7 @@ class ParseContext:
         elif rule.get_content is not None:
             self.find_inside(dom_)
             rule.get_content(dom_, self.parser.schema).for_each(
-                lambda node, offset, index: self.insert_node(node)
+                lambda node, offset, index: self.insert_node(node),
             )
         else:
             content_dom = dom_
@@ -807,7 +827,10 @@ class ParseContext:
         return False
 
     def enter(
-        self, type_: NodeType, attrs: Attrs | None = None, preserve_ws: WSType = None
+        self,
+        type_: NodeType,
+        attrs: Attrs | None = None,
+        preserve_ws: WSType = None,
     ) -> bool:
         ok = self.find_place(type_.create(attrs))
         if ok:
@@ -837,8 +860,14 @@ class ParseContext:
 
         self.nodes.append(
             NodeContext(
-                type_, attrs, top.active_marks, top.pending_marks, solid, None, options
-            )
+                type_,
+                attrs,
+                top.active_marks,
+                top.pending_marks,
+                solid,
+                None,
+                options,
+            ),
         )
 
         self.open += 1
@@ -849,7 +878,7 @@ class ParseContext:
         if i > self.open:
             while i > self.open:
                 self.nodes[i - 1].content.append(
-                    cast(Node, self.nodes[i].finish(open_end))
+                    cast(Node, self.nodes[i].finish(open_end)),
                 )
                 i -= 1
 
@@ -1111,7 +1140,8 @@ def node_contains(node: DOMNode, find: DOMNode) -> bool:
 
 def compare_document_position(node1: DOMNode, node2: DOMNode) -> int:
     if not isinstance(node1, lxml.etree._Element) or not isinstance(
-        node2, lxml.etree._Element
+        node2,
+        lxml.etree._Element,
     ):
         msg = "Both arguments must be lxml Element objects."
         raise ValueError(msg)

--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -992,7 +992,7 @@ class ParseContext:
 
                 d -= 1
 
-        for name, type_ in self.parser.schema.nodes.items():
+        for type_ in self.parser.schema.nodes.values():
             if type_.is_text_block and type_.default_attrs:
                 return type_
 
@@ -1069,14 +1069,14 @@ def parse_styles(style: str) -> list[str]:
 def mark_may_apply(mark_type: MarkType, node_type: NodeType) -> bool:
     nodes = node_type.schema.nodes
 
-    for name, parent in nodes.items():
+    for parent in nodes.values():
         if not parent.allows_mark_type(mark_type):
             continue
 
         seen: list[ContentMatch] = []
 
         def scan(match: ContentMatch) -> bool:
-            seen.append(match)
+            seen.append(match)  # noqa: B023
             i = 0
             while i < match.edge_count:
                 result = match.edge(i)
@@ -1085,7 +1085,7 @@ def mark_may_apply(mark_type: MarkType, node_type: NodeType) -> bool:
 
                 if _type == node_type:
                     return True
-                if _next not in seen and scan(_next):
+                if _next not in seen and scan(_next):  # noqa: B023
                     return True
 
                 i += 1

--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -1106,11 +1106,7 @@ def find_same_mark_in_set(mark: Mark, mark_set: list[Mark]) -> Mark | None:
 
 
 def node_contains(node: DOMNode, find: DOMNode) -> bool:
-    for child_node in node.iterdescendants():
-        if child_node == find:
-            return True
-
-    return False
+    return any(child_node == find for child_node in node.iterdescendants())
 
 
 def compare_document_position(node1: DOMNode, node2: DOMNode) -> int:

--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -1113,7 +1113,8 @@ def compare_document_position(node1: DOMNode, node2: DOMNode) -> int:
     if not isinstance(node1, lxml.etree._Element) or not isinstance(
         node2, lxml.etree._Element
     ):
-        raise ValueError("Both arguments must be lxml Element objects.")
+        msg = "Both arguments must be lxml Element objects."
+        raise ValueError(msg)
 
     tree = lxml.etree.ElementTree(node1)
 
@@ -1144,7 +1145,8 @@ def compare_document_position(node1: DOMNode, node2: DOMNode) -> int:
 
 def get_node_type(element: DOMNode) -> int:
     if not isinstance(element, lxml.etree._Element):
-        raise ValueError("The provided element is not an lxml HtmlElement.")
+        msg = "The provided element is not an lxml HtmlElement."
+        raise ValueError(msg)
 
     if isinstance(element, lxml.etree._Comment):
         return 8  # Comment node type

--- a/prosemirror/model/mark.py
+++ b/prosemirror/model/mark.py
@@ -1,5 +1,5 @@
 import copy
-from typing import TYPE_CHECKING, Any, Final, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Union, cast
 
 from prosemirror.utils import Attrs, JSONDict
 
@@ -8,14 +8,14 @@ if TYPE_CHECKING:
 
 
 class Mark:
-    none: Final[List["Mark"]] = []
+    none: Final[list["Mark"]] = []
 
     def __init__(self, type: "MarkType", attrs: Attrs) -> None:
         self.type = type
         self.attrs = attrs
 
-    def add_to_set(self, set: List["Mark"]) -> List["Mark"]:
-        copy: Optional[List["Mark"]] = None
+    def add_to_set(self, set: list["Mark"]) -> list["Mark"]:
+        copy: list["Mark"] | None = None
         placed = False
         for i in range(len(set)):
             other = set[i]
@@ -40,10 +40,10 @@ class Mark:
             copy.append(self)
         return copy
 
-    def remove_from_set(self, set: List["Mark"]) -> List["Mark"]:
+    def remove_from_set(self, set: list["Mark"]) -> list["Mark"]:
         return [item for item in set if not item.eq(self)]
 
-    def is_in_set(self, set: List["Mark"]) -> bool:
+    def is_in_set(self, set: list["Mark"]) -> bool:
         return any(item.eq(self) for item in set)
 
     def eq(self, other: "Mark") -> bool:
@@ -66,10 +66,10 @@ class Mark:
         type = schema.marks.get(name)
         if not type:
             raise ValueError(f"There is no mark type {name} in this schema")
-        return type.create(cast(Optional[JSONDict], json_data.get("attrs")))
+        return type.create(cast(JSONDict | None, json_data.get("attrs")))
 
     @classmethod
-    def same_set(cls, a: List["Mark"], b: List["Mark"]) -> bool:
+    def same_set(cls, a: list["Mark"], b: list["Mark"]) -> bool:
         if a == b:
             return True
         if len(a) != len(b):
@@ -77,7 +77,7 @@ class Mark:
         return all(item_a.eq(item_b) for (item_a, item_b) in zip(a, b))
 
     @classmethod
-    def set_from(cls, marks: Union[List["Mark"], "Mark", None]) -> List["Mark"]:
+    def set_from(cls, marks: Union[list["Mark"], "Mark", None]) -> list["Mark"]:
         if not marks:
             return cls.none
         if isinstance(marks, Mark):

--- a/prosemirror/model/mark.py
+++ b/prosemirror/model/mark.py
@@ -61,11 +61,13 @@ class Mark:
         json_data: JSONDict,
     ) -> "Mark":
         if not json_data:
-            raise ValueError("Invalid input for Mark.fromJSON")
+            msg = "Invalid input for Mark.fromJSON"
+            raise ValueError(msg)
         name = json_data["type"]
         type = schema.marks.get(name)
         if not type:
-            raise ValueError(f"There is no mark type {name} in this schema")
+            msg = f"There is no mark type {name} in this schema"
+            raise ValueError(msg)
         return type.create(cast(JSONDict | None, json_data.get("attrs")))
 
     @classmethod

--- a/prosemirror/model/mark.py
+++ b/prosemirror/model/mark.py
@@ -74,7 +74,7 @@ class Mark:
             return True
         if len(a) != len(b):
             return False
-        return all(item_a.eq(item_b) for (item_a, item_b) in zip(a, b))
+        return all(item_a.eq(item_b) for (item_a, item_b) in zip(a, b, strict=True))
 
     @classmethod
     def set_from(cls, marks: Union[list["Mark"], "Mark", None]) -> list["Mark"]:

--- a/prosemirror/model/node.py
+++ b/prosemirror/model/node.py
@@ -242,7 +242,8 @@ class Node:
     def content_match_at(self, index: int) -> "ContentMatch":
         match = self.type.content_match.match_fragment(self.content, 0, index)
         if not match:
-            raise ValueError("Called contentMatchAt on a node with invalid content")
+            msg = "Called contentMatchAt on a node with invalid content"
+            raise ValueError(msg)
         return match
 
     def can_replace(
@@ -285,17 +286,17 @@ class Node:
 
     def check(self) -> None:
         if not self.type.valid_content(self.content):
-            raise ValueError(
-                f"Invalid content for node {self.type.name}: {str(self.content)[:50]}"
-            )
+            msg = f"Invalid content for node {self.type.name}: {str(self.content)[:50]}"
+            raise ValueError(msg)
         copy = Mark.none
         for mark in self.marks:
             copy = mark.add_to_set(copy)
         if not Mark.same_set(copy, self.marks):
-            raise ValueError(
+            msg = (
                 f"Invalid collection of marks for node {self.type.name}:"
                 f" {[m.type.name for m in self.marks]!r}"
             )
+            raise ValueError(msg)
 
         def iteratee(node: "Node", offset: int, index: int) -> None:
             node.check()
@@ -329,11 +330,13 @@ class Node:
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not json_data:
-            raise ValueError("Invalid input for Node.from_json")
+            msg = "Invalid input for Node.from_json"
+            raise ValueError(msg)
         marks = None
         if json_data.get("marks"):
             if not isinstance(json_data["marks"], list):
-                raise ValueError("Invalid mark data for Node.fromJSON")
+                msg = "Invalid mark data for Node.fromJSON"
+                raise ValueError(msg)
             marks = [schema.mark_from_json(item) for item in json_data["marks"]]
         if json_data["type"] == "text":
             return schema.text(str(json_data["text"]), marks)
@@ -353,7 +356,8 @@ class TextNode(Node):
     ) -> None:
         super().__init__(type, attrs, None, marks)
         if not content:
-            raise ValueError("Empty text nodes are not allowed")
+            msg = "Empty text nodes are not allowed"
+            raise ValueError(msg)
         self.text = content
 
     def __str__(self) -> str:

--- a/prosemirror/model/node.py
+++ b/prosemirror/model/node.py
@@ -64,7 +64,8 @@ class Node:
         self.content.nodes_between(from_, to, f, start_pos, self)
 
     def descendants(
-        self, f: Callable[["Node", int, Optional["Node"], int], bool | None]
+        self,
+        f: Callable[["Node", int, Optional["Node"], int], bool | None],
     ) -> None:
         self.nodes_between(0, self.content.size, f)
 
@@ -127,7 +128,10 @@ class Node:
         return self.copy(self.content.cut(from_, to))
 
     def slice(
-        self, from_: int, to: int | None = None, include_parents: bool = False
+        self,
+        from_: int,
+        to: int | None = None,
+        include_parents: bool = False,
     ) -> Slice:
         if to is None:
             to = self.content.size
@@ -183,13 +187,19 @@ class Node:
         return ResolvedPos.resolve(self, pos)
 
     def range_has_mark(
-        self, from_: int, to: int, type: Union["Mark", "MarkType"]
+        self,
+        from_: int,
+        to: int,
+        type: Union["Mark", "MarkType"],
     ) -> bool:
         found = False
         if to > from_:
 
             def iteratee(
-                node: "Node", pos: int, parent: Optional["Node"], index: int
+                node: "Node",
+                pos: int,
+                parent: Optional["Node"],
+                index: int,
             ) -> bool:
                 nonlocal found
                 if type.is_in_set(node.marks):
@@ -268,7 +278,11 @@ class Node:
         return True
 
     def can_replace_with(
-        self, from_: int, to: int, type: "NodeType", marks: list[Mark] | None = None
+        self,
+        from_: int,
+        to: int,
+        type: "NodeType",
+        marks: list[Mark] | None = None,
     ) -> bool:
         if marks and not self.type.allows_marks(marks):
             return False
@@ -342,7 +356,9 @@ class Node:
             return schema.text(str(json_data["text"]), marks)
         content = Fragment.from_json(schema, json_data.get("content"))
         return schema.node_type(str(json_data["type"])).create(
-            cast("Attrs", json_data.get("attrs")), content, marks
+            cast("Attrs", json_data.get("attrs")),
+            content,
+            marks,
         )
 
 
@@ -403,7 +419,7 @@ class TextNode(Node):
         if from_ == 0 and to == text_length(self.text):
             return self
         substring = self.text.encode("utf-16-le")[2 * from_ : 2 * to].decode(
-            "utf-16-le"
+            "utf-16-le",
         )
         return self.with_text(substring)
 

--- a/prosemirror/model/node.py
+++ b/prosemirror/model/node.py
@@ -204,8 +204,8 @@ class Node:
         return self.type.is_block
 
     @property
-    def is_text_block(self) -> bool:
-        return self.type.is_text_block
+    def is_textblock(self) -> bool:
+        return self.type.is_textblock
 
     @property
     def inline_content(self) -> bool:

--- a/prosemirror/model/node.py
+++ b/prosemirror/model/node.py
@@ -228,11 +228,7 @@ class Node:
         return self.type.is_atom
 
     def __str__(self) -> str:
-        to_debug_string = (
-            self.type.spec["toDebugString"]
-            if "toDebugString" in self.type.spec
-            else None
-        )
+        to_debug_string = self.type.spec.get("toDebugString", None)
         if to_debug_string:
             return to_debug_string(self)
         name = self.type.name
@@ -363,11 +359,7 @@ class TextNode(Node):
     def __str__(self) -> str:
         import json
 
-        to_debug_string = (
-            self.type.spec["toDebugString"]
-            if "toDebugString" in self.type.spec
-            else None
-        )
+        to_debug_string = self.type.spec.get("toDebugString", None)
         if to_debug_string:
             return to_debug_string(self)
         return wrap_marks(self.marks, json.dumps(self.text))

--- a/prosemirror/model/replace.py
+++ b/prosemirror/model/replace.py
@@ -22,11 +22,13 @@ def remove_range(content: Fragment, from_: int, to: int) -> Fragment:
     index_to, offset_to = to_index_info["index"], to_index_info["offset"]
     if offset == from_ or cast("Node", child).is_text:
         if offset_to != to and not content.child(index_to).is_text:
-            raise ValueError("removing non-flat range")
+            msg = "removing non-flat range"
+            raise ValueError(msg)
         return content.cut(0, from_).append(content.cut(to))
     assert child
     if index != index_to:
-        raise ValueError("removing non-flat range")
+        msg = "removing non-flat range"
+        raise ValueError(msg)
     return content.replace_child(
         index,
         child.copy(remove_range(child.content, from_ - offset - 1, to - offset - 1)),
@@ -112,7 +114,8 @@ class Slice:
         open_start = json_data.get("openStart", 0) or 0
         open_end = json_data.get("openEnd", 0) or 0
         if not isinstance(open_start, int) or not isinstance(open_end, int):
-            raise ValueError("invalid input for Slice.from_json")
+            msg = "invalid input for Slice.from_json"
+            raise ValueError(msg)
         return cls(
             Fragment.from_json(schema, json_data.get("content")),
             open_start,
@@ -139,9 +142,11 @@ Slice.empty = Slice(Fragment.empty, 0, 0)
 
 def replace(from_: "ResolvedPos", to: "ResolvedPos", slice: Slice) -> "Node":
     if slice.open_start > from_.depth:
-        raise ReplaceError("Inserted content deeper than insertion position")
+        msg = "Inserted content deeper than insertion position"
+        raise ReplaceError(msg)
     if from_.depth - slice.open_start != to.depth - slice.open_end:
-        raise ReplaceError("Inconsistent open depths")
+        msg = "Inconsistent open depths"
+        raise ReplaceError(msg)
     return replace_outer(from_, to, slice, 0)
 
 
@@ -177,7 +182,8 @@ def replace_outer(
 
 def check_join(main: "Node", sub: "Node") -> None:
     if not sub.type.compatible_content(main.type):
-        raise ReplaceError(f"Cannot join {sub.type.name} onto {main.type.name}")
+        msg = f"Cannot join {sub.type.name} onto {main.type.name}"
+        raise ReplaceError(msg)
 
 
 def joinable(before: "ResolvedPos", after: "ResolvedPos", depth: int) -> "Node":
@@ -220,7 +226,8 @@ def add_range(
 
 def close(node: "Node", content: Fragment) -> "Node":
     if not node.type.valid_content(content):
-        raise ReplaceError(f"Invalid content for node {node.type.name}")
+        msg = f"Invalid content for node {node.type.name}"
+        raise ReplaceError(msg)
     return node.copy(content)
 
 

--- a/prosemirror/model/replace.py
+++ b/prosemirror/model/replace.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from prosemirror.utils import JSONDict
 
@@ -35,7 +35,7 @@ def remove_range(content: Fragment, from_: int, to: int) -> Fragment:
 
 def insert_into(
     content: Fragment, dist: int, insert: Fragment, parent: Optional["Node"]
-) -> Optional[Fragment]:
+) -> Fragment | None:
     a = content.find_index(dist)
     index, offset = a["index"], a["offset"]
     child = content.maybe_child(index)
@@ -85,7 +85,7 @@ class Slice:
     def __str__(self) -> str:
         return f"{self.content}({self.open_start},{self.open_end})"
 
-    def to_json(self) -> Optional[JSONDict]:
+    def to_json(self) -> JSONDict | None:
         if not self.content.size:
             return None
         json: JSONDict = {"content": self.content.to_json()}
@@ -105,7 +105,7 @@ class Slice:
     def from_json(
         cls,
         schema: "Schema[Any, Any]",
-        json_data: Optional[JSONDict],
+        json_data: JSONDict | None,
     ) -> "Slice":
         if not json_data:
             return cls.empty
@@ -186,7 +186,7 @@ def joinable(before: "ResolvedPos", after: "ResolvedPos", depth: int) -> "Node":
     return node
 
 
-def add_node(child: "Node", target: List["Node"]) -> None:
+def add_node(child: "Node", target: list["Node"]) -> None:
     last = len(target) - 1
     if last >= 0 and pm_node.is_text(child) and child.same_markup(target[last]):
         target[last] = child.with_text(cast("TextNode", target[last]).text + child.text)
@@ -198,7 +198,7 @@ def add_range(
     start: Optional["ResolvedPos"],
     end: Optional["ResolvedPos"],
     depth: int,
-    target: List["Node"],
+    target: list["Node"],
 ) -> None:
     node = cast("ResolvedPos", end or start).node(depth)
     start_index = 0
@@ -233,7 +233,7 @@ def replace_three_way(
 ) -> Fragment:
     open_start = joinable(from_, start, depth + 1) if from_.depth > depth else None
     open_end = joinable(end, to, depth + 1) if to.depth > depth else None
-    content: List["Node"] = []
+    content: list["Node"] = []
     add_range(None, from_, depth, content)
     if open_start and open_end and start.index(depth) == end.index(depth):
         check_join(open_start, open_end)
@@ -254,7 +254,7 @@ def replace_three_way(
 
 
 def replace_two_way(from_: "ResolvedPos", to: "ResolvedPos", depth: int) -> Fragment:
-    content: List["Node"] = []
+    content: list["Node"] = []
     add_range(None, from_, depth, content)
     if from_.depth > depth:
         type = joinable(from_, to, depth + 1)
@@ -265,7 +265,7 @@ def replace_two_way(from_: "ResolvedPos", to: "ResolvedPos", depth: int) -> Frag
 
 def prepare_slice_for_replace(
     slice: Slice, along: "ResolvedPos"
-) -> Dict[str, "ResolvedPos"]:
+) -> dict[str, "ResolvedPos"]:
     extra = along.depth - slice.open_start
     parent = along.node(extra)
     node = parent.copy(slice.content)

--- a/prosemirror/model/replace.py
+++ b/prosemirror/model/replace.py
@@ -36,7 +36,10 @@ def remove_range(content: Fragment, from_: int, to: int) -> Fragment:
 
 
 def insert_into(
-    content: Fragment, dist: int, insert: Fragment, parent: Optional["Node"]
+    content: Fragment,
+    dist: int,
+    insert: Fragment,
+    parent: Optional["Node"],
 ) -> Fragment | None:
     a = content.find_index(dist)
     index, offset = a["index"], a["offset"]
@@ -151,7 +154,10 @@ def replace(from_: "ResolvedPos", to: "ResolvedPos", slice: Slice) -> "Node":
 
 
 def replace_outer(
-    from_: "ResolvedPos", to: "ResolvedPos", slice: Slice, depth: int
+    from_: "ResolvedPos",
+    to: "ResolvedPos",
+    slice: Slice,
+    depth: int,
 ) -> "Node":
     index = from_.index(depth)
     node = from_.node(depth)
@@ -251,7 +257,8 @@ def replace_three_way(
     else:
         if open_start:
             add_node(
-                close(open_start, replace_two_way(from_, start, depth + 1)), content
+                close(open_start, replace_two_way(from_, start, depth + 1)),
+                content,
             )
         add_range(start, end, depth, content)
         if open_end:
@@ -271,7 +278,8 @@ def replace_two_way(from_: "ResolvedPos", to: "ResolvedPos", depth: int) -> Frag
 
 
 def prepare_slice_for_replace(
-    slice: Slice, along: "ResolvedPos"
+    slice: Slice,
+    along: "ResolvedPos",
 ) -> dict[str, "ResolvedPos"]:
     extra = along.depth - slice.open_start
     parent = along.node(extra)

--- a/prosemirror/model/resolvedpos.py
+++ b/prosemirror/model/resolvedpos.py
@@ -52,7 +52,8 @@ class ResolvedPos:
     def before(self, depth: int | None = None) -> int:
         depth = self.resolve_depth(depth)
         if not depth:
-            raise ValueError("There is no position before the top level node")
+            msg = "There is no position before the top level node"
+            raise ValueError(msg)
         return (
             self.pos if depth == self.depth + 1 else cast(int, self.path[depth * 3 - 1])
         )
@@ -60,7 +61,8 @@ class ResolvedPos:
     def after(self, depth: int | None = None) -> int:
         depth = self.resolve_depth(depth)
         if not depth:
-            raise ValueError("There is no position after the top level node")
+            msg = "There is no position after the top level node"
+            raise ValueError(msg)
         return (
             self.pos
             if depth == self.depth + 1
@@ -181,7 +183,8 @@ class ResolvedPos:
     @classmethod
     def resolve(cls, doc: "Node", pos: int) -> "ResolvedPos":
         if not (pos >= 0 and pos <= doc.content.size):
-            raise ValueError(f"Position {pos} out of range")
+            msg = f"Position {pos} out of range"
+            raise ValueError(msg)
         path: list["Node" | int] = []
         start = 0
         parent_offset = pos

--- a/prosemirror/model/resolvedpos.py
+++ b/prosemirror/model/resolvedpos.py
@@ -9,7 +9,10 @@ if TYPE_CHECKING:
 
 class ResolvedPos:
     def __init__(
-        self, pos: int, path: list[Union["Node", int]], parent_offset: int
+        self,
+        pos: int,
+        path: list[Union["Node", int]],
+        parent_offset: int,
     ) -> None:
         self.pos = pos
         self.path = path

--- a/prosemirror/model/schema.py
+++ b/prosemirror/model/schema.py
@@ -114,10 +114,7 @@ class NodeType:
         )
 
     def has_required_attrs(self) -> bool:
-        for n in self.attrs:
-            if self.attrs[n].is_required:
-                return True
-        return False
+        return any(self.attrs[n].is_required for n in self.attrs)
 
     def compatible_content(self, other: "NodeType") -> bool:
         return self == other or (self.content_match.compatible(other.content_match))
@@ -277,10 +274,8 @@ class MarkType:
         cls, marks: dict["Marks", "MarkSpec"], schema: "Schema[Nodes, Marks]"
     ) -> dict["Marks", "MarkType"]:
         result = {}
-        rank = 0
-        for name, spec in marks.items():
+        for rank, (name, spec) in enumerate(marks.items()):
             result[name] = MarkType(name, rank, schema, spec)
-            rank += 1
         return result
 
     def remove_from_set(self, set_: list["Mark"]) -> list["Mark"]:

--- a/prosemirror/model/schema.py
+++ b/prosemirror/model/schema.py
@@ -1,17 +1,15 @@
+from collections.abc import Callable
 from typing import (
     Any,
-    Callable,
-    Dict,
     Generic,
-    List,
     Literal,
     Optional,
+    TypeAlias,
     TypeVar,
-    Union,
     cast,
 )
 
-from typing_extensions import NotRequired, TypeAlias, TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from prosemirror.model.content import ContentMatch
 from prosemirror.model.fragment import Fragment
@@ -20,7 +18,7 @@ from prosemirror.model.node import Node, TextNode
 from prosemirror.utils import JSON, Attrs, JSONDict
 
 
-def default_attrs(attrs: "Attributes") -> Optional[Attrs]:
+def default_attrs(attrs: "Attributes") -> Attrs | None:
     defaults = {}
     for attr_name, attr in attrs.items():
         if not attr.has_default:
@@ -29,7 +27,7 @@ def default_attrs(attrs: "Attributes") -> Optional[Attrs]:
     return defaults
 
 
-def compute_attrs(attrs: "Attributes", value: Optional[Attrs]) -> Attrs:
+def compute_attrs(attrs: "Attributes", value: Attrs | None) -> Attrs:
     built = {}
     for name in attrs:
         given = None
@@ -69,7 +67,7 @@ class NodeType:
 
     inline_content: bool
 
-    mark_set: Optional[List["MarkType"]]
+    mark_set: list["MarkType"] | None
 
     def __init__(self, name: str, schema: "Schema[Any, Any]", spec: "NodeSpec") -> None:
         self.name = name
@@ -78,7 +76,7 @@ class NodeType:
         self.groups = spec["group"].split(" ") if "group" in spec else []
         self.attrs = init_attrs(spec.get("attrs"))
         self.default_attrs = default_attrs(self.attrs)
-        self._content_match: Optional[ContentMatch] = None
+        self._content_match: ContentMatch | None = None
         self.mark_set = None
         self.inline_content = False
         self.is_block = not (spec.get("inline") or name == "text")
@@ -124,16 +122,16 @@ class NodeType:
     def compatible_content(self, other: "NodeType") -> bool:
         return self == other or (self.content_match.compatible(other.content_match))
 
-    def compute_attrs(self, attrs: Optional[Attrs]) -> Attrs:
+    def compute_attrs(self, attrs: Attrs | None) -> Attrs:
         if attrs is None and self.default_attrs is not None:
             return self.default_attrs
         return compute_attrs(self.attrs, attrs)
 
     def create(
         self,
-        attrs: Optional[Attrs] = None,
-        content: Union[Fragment, Node, List[Node], None] = None,
-        marks: Optional[List[Mark]] = None,
+        attrs: Attrs | None = None,
+        content: Fragment | Node | list[Node] | None = None,
+        marks: list[Mark] | None = None,
     ) -> Node:
         if self.is_text:
             raise ValueError("NodeType.create cannot construct text nodes")
@@ -146,9 +144,9 @@ class NodeType:
 
     def create_checked(
         self,
-        attrs: Optional[Attrs] = None,
-        content: Union[Fragment, Node, List[Node], None] = None,
-        marks: Optional[List[Mark]] = None,
+        attrs: Attrs | None = None,
+        content: Fragment | Node | list[Node] | None = None,
+        marks: list[Mark] | None = None,
     ) -> Node:
         content = Fragment.from_(content)
         if not self.valid_content(content):
@@ -157,10 +155,10 @@ class NodeType:
 
     def create_and_fill(
         self,
-        attrs: Optional[Attrs] = None,
-        content: Union[Fragment, Node, List[Node], None] = None,
-        marks: Optional[List[Mark]] = None,
-    ) -> Optional[Node]:
+        attrs: Attrs | None = None,
+        content: Fragment | Node | list[Node] | None = None,
+        marks: list[Mark] | None = None,
+    ) -> Node | None:
         attrs = self.compute_attrs(attrs)
         frag = Fragment.from_(content)
         if frag.size:
@@ -188,15 +186,15 @@ class NodeType:
     def allows_mark_type(self, mark_type: "MarkType") -> bool:
         return self.mark_set is None or mark_type in self.mark_set
 
-    def allows_marks(self, marks: List[Mark]) -> bool:
+    def allows_marks(self, marks: list[Mark]) -> bool:
         if self.mark_set is None:
             return True
         return all(self.allows_mark_type(mark.type) for mark in marks)
 
-    def allowed_marks(self, marks: List[Mark]) -> List[Mark]:
+    def allowed_marks(self, marks: list[Mark]) -> list[Mark]:
         if self.mark_set is None:
             return marks
-        copy: Optional[List[Mark]] = None
+        copy: list[Mark] | None = None
         for i, mark in enumerate(marks):
             if not self.allows_mark_type(mark.type):
                 if not copy:
@@ -212,9 +210,9 @@ class NodeType:
 
     @classmethod
     def compile(
-        cls, nodes: Dict["Nodes", "NodeSpec"], schema: "Schema[Nodes, Marks]"
-    ) -> Dict["Nodes", "NodeType"]:
-        result: Dict["Nodes", "NodeType"] = {}
+        cls, nodes: dict["Nodes", "NodeSpec"], schema: "Schema[Nodes, Marks]"
+    ) -> dict["Nodes", "NodeType"]:
+        result: dict["Nodes", "NodeType"] = {}
 
         for name, spec in nodes.items():
             result[name] = NodeType(name, schema, spec)
@@ -235,7 +233,7 @@ class NodeType:
         return self.__str__()
 
 
-Attributes: TypeAlias = Dict[str, "Attribute"]
+Attributes: TypeAlias = dict[str, "Attribute"]
 
 
 class Attribute:
@@ -249,8 +247,8 @@ class Attribute:
 
 
 class MarkType:
-    excluded: List["MarkType"]
-    instance: Optional[Mark]
+    excluded: list["MarkType"]
+    instance: Mark | None
 
     def __init__(
         self, name: str, rank: int, schema: "Schema[Any, Any]", spec: "MarkSpec"
@@ -268,7 +266,7 @@ class MarkType:
 
     def create(
         self,
-        attrs: Optional[Attrs] = None,
+        attrs: Attrs | None = None,
     ) -> Mark:
         if not attrs and self.instance:
             return self.instance
@@ -276,8 +274,8 @@ class MarkType:
 
     @classmethod
     def compile(
-        cls, marks: Dict["Marks", "MarkSpec"], schema: "Schema[Nodes, Marks]"
-    ) -> Dict["Marks", "MarkType"]:
+        cls, marks: dict["Marks", "MarkSpec"], schema: "Schema[Nodes, Marks]"
+    ) -> dict["Marks", "MarkType"]:
         result = {}
         rank = 0
         for name, spec in marks.items():
@@ -285,10 +283,10 @@ class MarkType:
             rank += 1
         return result
 
-    def remove_from_set(self, set_: List["Mark"]) -> List["Mark"]:
+    def remove_from_set(self, set_: list["Mark"]) -> list["Mark"]:
         return [item for item in set_ if item.type != self]
 
-    def is_in_set(self, set: List[Mark]) -> Optional[Mark]:
+    def is_in_set(self, set: list[Mark]) -> Mark | None:
         return next((item for item in set if item.type == self), None)
 
     def excludes(self, other: "MarkType") -> bool:
@@ -311,13 +309,13 @@ class SchemaSpec(TypedDict, Generic[Nodes, Marks]):
     # determines which [parse rules](#model.NodeSpec.parseDOM) take
     # precedence by default, and which nodes come first in a given
     # [group](#model.NodeSpec.group).
-    nodes: Dict[Nodes, "NodeSpec"]
+    nodes: dict[Nodes, "NodeSpec"]
 
     # The mark types that exist in this schema. The order in which they
     # are provided determines the order in which [mark
     # sets](#model.Mark.addToSet) are sorted and in which [parse
     # rules](#model.MarkSpec.parseDOM) are tried.
-    marks: NotRequired[Dict[Marks, "MarkSpec"]]
+    marks: NotRequired[dict[Marks, "MarkSpec"]]
 
     # The name of the default top-level node for the schema. Defaults
     # to `"doc"`.
@@ -344,12 +342,12 @@ class NodeSpec(TypedDict, total=False):
     defining: bool
     isolating: bool
     toDOM: Callable[[Node], Any]  # FIXME: add types
-    parseDOM: List[Dict[str, Any]]  # FIXME: add types
+    parseDOM: list[dict[str, Any]]  # FIXME: add types
     toDebugString: Callable[[Node], str]
     leafText: Callable[[Node], str]
 
 
-AttributeSpecs: TypeAlias = Dict[str, "AttributeSpec"]
+AttributeSpecs: TypeAlias = dict[str, "AttributeSpec"]
 
 
 class MarkSpec(TypedDict, total=False):
@@ -359,7 +357,7 @@ class MarkSpec(TypedDict, total=False):
     group: str
     spanning: bool
     toDOM: Callable[[Mark, bool], Any]  # FIXME: add types
-    parseDOM: List[Dict[str, Any]]  # FIXME: add types
+    parseDOM: list[dict[str, Any]]  # FIXME: add types
 
 
 class AttributeSpec(TypedDict, total=False):
@@ -369,9 +367,9 @@ class AttributeSpec(TypedDict, total=False):
 class Schema(Generic[Nodes, Marks]):
     spec: SchemaSpec[Nodes, Marks]
 
-    nodes: Dict[Nodes, "NodeType"]
+    nodes: dict[Nodes, "NodeType"]
 
-    marks: Dict[Marks, "MarkType"]
+    marks: dict[Marks, "MarkType"]
 
     def __init__(self, spec: SchemaSpec[Nodes, Marks]) -> None:
         self.spec = spec
@@ -386,7 +384,7 @@ class Schema(Generic[Nodes, Marks]):
             mark_expr = type.spec.get("marks")
             if content_expr not in content_expr_cache:
                 content_expr_cache[content_expr] = ContentMatch.parse(
-                    content_expr, cast(Dict[str, "NodeType"], self.nodes)
+                    content_expr, cast(dict[str, "NodeType"], self.nodes)
                 )
 
             type.content_match = content_expr_cache[content_expr]
@@ -408,15 +406,15 @@ class Schema(Generic[Nodes, Marks]):
             )
 
         self.top_node_type = self.nodes[cast(Nodes, self.spec.get("topNode") or "doc")]
-        self.cached: Dict[str, Any] = {}
+        self.cached: dict[str, Any] = {}
         self.cached["wrappings"] = {}
 
     def node(
         self,
-        type: Union[str, NodeType],
-        attrs: Optional[Attrs] = None,
-        content: Union[Fragment, Node, List[Node], None] = None,
-        marks: Optional[List[Mark]] = None,
+        type: str | NodeType,
+        attrs: Attrs | None = None,
+        content: Fragment | Node | list[Node] | None = None,
+        marks: list[Mark] | None = None,
     ) -> Node:
         if isinstance(type, str):
             type = self.node_type(type)
@@ -426,7 +424,7 @@ class Schema(Generic[Nodes, Marks]):
             raise ValueError(f"Node type from different schema used ({type.name})")
         return type.create_checked(attrs, content, marks)
 
-    def text(self, text: str, marks: Optional[List[Mark]] = None) -> TextNode:
+    def text(self, text: str, marks: list[Mark] | None = None) -> TextNode:
         type = self.nodes[cast(Nodes, "text")]
         return TextNode(
             type, cast(Attrs, type.default_attrs), text, Mark.set_from(marks)
@@ -434,14 +432,14 @@ class Schema(Generic[Nodes, Marks]):
 
     def mark(
         self,
-        type: Union[str, MarkType],
-        attrs: Optional[Attrs] = None,
+        type: str | MarkType,
+        attrs: Attrs | None = None,
     ) -> Mark:
         if isinstance(type, str):
             type = self.marks[cast(Marks, type)]
         return type.create(attrs)
 
-    def node_from_json(self, json_data: JSONDict) -> Union[Node, TextNode]:
+    def node_from_json(self, json_data: JSONDict) -> Node | TextNode:
         return Node.from_json(self, json_data)
 
     def mark_from_json(
@@ -457,7 +455,7 @@ class Schema(Generic[Nodes, Marks]):
         return found
 
 
-def gather_marks(schema: Schema[Any, Any], marks: List[str]) -> List[MarkType]:
+def gather_marks(schema: Schema[Any, Any], marks: list[str]) -> list[MarkType]:
     found = []
     for name in marks:
         mark = schema.marks.get(name)

--- a/prosemirror/model/schema.py
+++ b/prosemirror/model/schema.py
@@ -208,7 +208,9 @@ class NodeType:
 
     @classmethod
     def compile(
-        cls, nodes: dict["Nodes", "NodeSpec"], schema: "Schema[Nodes, Marks]"
+        cls,
+        nodes: dict["Nodes", "NodeSpec"],
+        schema: "Schema[Nodes, Marks]",
     ) -> dict["Nodes", "NodeType"]:
         result: dict["Nodes", "NodeType"] = {}
 
@@ -252,7 +254,11 @@ class MarkType:
     instance: Mark | None
 
     def __init__(
-        self, name: str, rank: int, schema: "Schema[Any, Any]", spec: "MarkSpec"
+        self,
+        name: str,
+        rank: int,
+        schema: "Schema[Any, Any]",
+        spec: "MarkSpec",
     ) -> None:
         self.name = name
         self.schema = schema
@@ -275,7 +281,9 @@ class MarkType:
 
     @classmethod
     def compile(
-        cls, marks: dict["Marks", "MarkSpec"], schema: "Schema[Nodes, Marks]"
+        cls,
+        marks: dict["Marks", "MarkSpec"],
+        schema: "Schema[Nodes, Marks]",
     ) -> dict["Marks", "MarkType"]:
         result = {}
         for rank, (name, spec) in enumerate(marks.items()):
@@ -384,7 +392,8 @@ class Schema(Generic[Nodes, Marks]):
             mark_expr = type.spec.get("marks")
             if content_expr not in content_expr_cache:
                 content_expr_cache[content_expr] = ContentMatch.parse(
-                    content_expr, cast(dict[str, "NodeType"], self.nodes)
+                    content_expr,
+                    cast(dict[str, "NodeType"], self.nodes),
                 )
 
             type.content_match = content_expr_cache[content_expr]
@@ -429,7 +438,10 @@ class Schema(Generic[Nodes, Marks]):
     def text(self, text: str, marks: list[Mark] | None = None) -> TextNode:
         type = self.nodes[cast(Nodes, "text")]
         return TextNode(
-            type, cast(Attrs, type.default_attrs), text, Mark.set_from(marks)
+            type,
+            cast(Attrs, type.default_attrs),
+            text,
+            Mark.set_from(marks),
         )
 
     def mark(

--- a/prosemirror/model/schema.py
+++ b/prosemirror/model/schema.py
@@ -131,7 +131,8 @@ class NodeType:
         marks: list[Mark] | None = None,
     ) -> Node:
         if self.is_text:
-            raise ValueError("NodeType.create cannot construct text nodes")
+            msg = "NodeType.create cannot construct text nodes"
+            raise ValueError(msg)
         return Node(
             self,
             self.compute_attrs(attrs),
@@ -216,11 +217,14 @@ class NodeType:
 
         top_node = cast(Nodes, schema.spec.get("topNode") or "doc")
         if not result.get(top_node):
-            raise ValueError(f"Schema is missing its top node type {top_node}")
+            msg = f"Schema is missing its top node type {top_node}"
+            raise ValueError(msg)
         if not result.get(cast(Nodes, "text")):
-            raise ValueError("every schema needs a 'text' type")
+            msg = "every schema needs a 'text' type"
+            raise ValueError(msg)
         if result[cast(Nodes, "text")].attrs:
-            raise ValueError("the text node type should not have attributes")
+            msg = "the text node type should not have attributes"
+            raise ValueError(msg)
         return result
 
     def __str__(self) -> str:
@@ -373,7 +377,8 @@ class Schema(Generic[Nodes, Marks]):
         content_expr_cache = {}
         for prop in self.nodes:
             if prop in self.marks:
-                raise ValueError(f"{prop} can not be both a node and a mark")
+                msg = f"{prop} can not be both a node and a mark"
+                raise ValueError(msg)
             type = self.nodes[prop]
             content_expr = type.spec.get("content", "")
             mark_expr = type.spec.get("marks")
@@ -414,9 +419,11 @@ class Schema(Generic[Nodes, Marks]):
         if isinstance(type, str):
             type = self.node_type(type)
         elif not isinstance(type, NodeType):
-            raise ValueError(f"Invalid node type: {type}")
+            msg = f"Invalid node type: {type}"
+            raise ValueError(msg)
         elif type.schema != self:
-            raise ValueError(f"Node type from different schema used ({type.name})")
+            msg = f"Node type from different schema used ({type.name})"
+            raise ValueError(msg)
         return type.create_checked(attrs, content, marks)
 
     def text(self, text: str, marks: list[Mark] | None = None) -> TextNode:
@@ -446,7 +453,8 @@ class Schema(Generic[Nodes, Marks]):
     def node_type(self, name: str) -> NodeType:
         found = self.nodes.get(cast(Nodes, name))
         if not found:
-            raise ValueError(f"Unknown node type: {name}")
+            msg = f"Unknown node type: {name}"
+            raise ValueError(msg)
         return found
 
 
@@ -465,5 +473,6 @@ def gather_marks(schema: Schema[Any, Any], marks: list[str]) -> list[MarkType]:
                     ok = mark
                     found.append(mark)
         if not ok:
-            raise SyntaxError(f"unknow mark type: '{mark}'")
+            msg = f"unknow mark type: '{mark}'"
+            raise SyntaxError(msg)
     return found

--- a/prosemirror/model/schema.py
+++ b/prosemirror/model/schema.py
@@ -96,7 +96,7 @@ class NodeType:
         return not self.is_block
 
     @property
-    def is_text_block(self) -> bool:  # FIXME: name is wrong, should be is_textblock
+    def is_textblock(self) -> bool:
         return self.is_block and self.inline_content
 
     @property

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -43,7 +43,10 @@ SELF_CLOSING_ELEMENTS = frozenset({
 
 class Element(DocumentFragment):
     def __init__(
-        self, name: str, attrs: dict[str, str], children: list[HTMLNode]
+        self,
+        name: str,
+        attrs: dict[str, str],
+        children: list[HTMLNode],
     ) -> None:
         self.name = name
         self.attrs = attrs
@@ -72,7 +75,9 @@ class DOMSerializer:
         self.marks = marks
 
     def serialize_fragment(
-        self, fragment: Fragment, target: Element | DocumentFragment | None = None
+        self,
+        fragment: Fragment,
+        target: Element | DocumentFragment | None = None,
     ) -> DocumentFragment:
         tgt: DocumentFragment = target or DocumentFragment(children=[])
 
@@ -134,7 +139,9 @@ class DOMSerializer:
         return dom
 
     def serialize_mark(
-        self, mark: Mark, inline: bool
+        self,
+        mark: Mark,
+        inline: bool,
     ) -> tuple[HTMLNode, Element | None] | None:
         to_dom = self.marks.get(mark.type.name)
         if to_dom:
@@ -186,7 +193,8 @@ class DOMSerializer:
 
     @classmethod
     def nodes_from_schema(
-        cls, schema: Schema[str, Any]
+        cls,
+        schema: Schema[str, Any],
     ) -> dict[str, Callable[["Node"], HTMLOutputSpec]]:
         result = gather_to_dom(schema.nodes)
         if "text" not in result:
@@ -195,7 +203,8 @@ class DOMSerializer:
 
     @classmethod
     def marks_from_schema(
-        cls, schema: Schema[Any, Any]
+        cls,
+        schema: Schema[Any, Any],
     ) -> dict[str, Callable[["Mark", bool], HTMLOutputSpec]]:
         return gather_to_dom(schema.marks)
 

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -118,7 +118,8 @@ class DOMSerializer:
         dom, content_dom = type(self).render_spec(self.nodes[node.type.name](node))
         if content_dom:
             if node.is_leaf:
-                raise Exception("Content hole not allowed in a leaf node spec")
+                msg = "Content hole not allowed in a leaf node spec"
+                raise Exception(msg)
             self.serialize_fragment(node.content, content_dom)
         return dom
 
@@ -148,7 +149,8 @@ class DOMSerializer:
             return structure, None
         tag_name = structure[0]
         if " " in tag_name[1:]:
-            raise NotImplementedError("XML namespaces are not supported")
+            msg = "XML namespaces are not supported"
+            raise NotImplementedError(msg)
         content_dom: Element | None = None
         dom = Element(name=tag_name, attrs={}, children=[])
         attrs = structure[1] if len(structure) > 1 else None
@@ -159,21 +161,22 @@ class DOMSerializer:
                 if value is None:
                     continue
                 if " " in name[1:]:
-                    raise NotImplementedError("XML namespaces are not supported")
+                    msg = "XML namespaces are not supported"
+                    raise NotImplementedError(msg)
                 dom.attrs[name] = value
         for i in range(start, len(structure)):
             child = structure[i]
             if child == 0:
                 if i < len(structure) - 1 or i > start:
-                    raise Exception(
-                        "Content hole must be the only child of its parent node"
-                    )
+                    msg = "Content hole must be the only child of its parent node"
+                    raise Exception(msg)
                 return dom, dom
             inner, inner_content = cls.render_spec(child)
             dom.children.append(inner)
             if inner_content:
                 if content_dom:
-                    raise Exception("Multiple content holes")
+                    msg = "Multiple content holes"
+                    raise Exception(msg)
                 content_dom = inner_content
         return dom, content_dom
 

--- a/prosemirror/schema/basic/schema_basic.py
+++ b/prosemirror/schema/basic/schema_basic.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from prosemirror.model import Schema
 from prosemirror.model.schema import MarkSpec, NodeSpec
@@ -9,7 +9,7 @@ hr_dom = ["hr"]
 pre_dom = ["pre", ["code", 0]]
 br_dom = ["br"]
 
-nodes: Dict[str, NodeSpec] = {
+nodes: dict[str, NodeSpec] = {
     "doc": {"content": "block+"},
     "paragraph": {
         "content": "inline*",
@@ -90,7 +90,7 @@ em_dom = ["em", 0]
 strong_dom = ["strong", 0]
 code_dom = ["code", 0]
 
-marks: Dict[str, MarkSpec] = {
+marks: dict[str, MarkSpec] = {
     "link": {
         "attrs": {"href": {}, "title": {"default": None}},
         "inclusive": False,

--- a/prosemirror/schema/basic/schema_basic.py
+++ b/prosemirror/schema/basic/schema_basic.py
@@ -66,7 +66,7 @@ nodes: dict[str, NodeSpec] = {
                     "src": dom_.get("src"),
                     "title": dom_.get("title"),
                 },
-            }
+            },
         ],
         "toDOM": lambda node: [
             "img",

--- a/prosemirror/schema/list/schema_list.py
+++ b/prosemirror/schema/list/schema_list.py
@@ -27,15 +27,19 @@ def add(obj: "NodeSpec", props: "NodeSpec") -> "NodeSpec":
 
 
 def add_list_nodes(
-    nodes: dict["Nodes", "NodeSpec"], item_content: str, list_group: str
+    nodes: dict["Nodes", "NodeSpec"],
+    item_content: str,
+    list_group: str,
 ) -> dict["Nodes", "NodeSpec"]:
     copy = nodes.copy()
     copy.update({
         cast(Nodes, "ordered_list"): add(
-            orderd_list, NodeSpec(content="list_item+", group=list_group)
+            orderd_list,
+            NodeSpec(content="list_item+", group=list_group),
         ),
         cast(Nodes, "bullet_list"): add(
-            bullet_list, NodeSpec(content="list_item+", group=list_group)
+            bullet_list,
+            NodeSpec(content="list_item+", group=list_group),
         ),
         cast(Nodes, "list_item"): add(list_item, NodeSpec(content=item_content)),
     })

--- a/prosemirror/schema/list/schema_list.py
+++ b/prosemirror/schema/list/schema_list.py
@@ -1,4 +1,4 @@
-from typing import Dict, cast
+from typing import cast
 
 from prosemirror.model.schema import Nodes, NodeSpec
 
@@ -27,8 +27,8 @@ def add(obj: "NodeSpec", props: "NodeSpec") -> "NodeSpec":
 
 
 def add_list_nodes(
-    nodes: Dict["Nodes", "NodeSpec"], item_content: str, list_group: str
-) -> Dict["Nodes", "NodeSpec"]:
+    nodes: dict["Nodes", "NodeSpec"], item_content: str, list_group: str
+) -> dict["Nodes", "NodeSpec"]:
     copy = nodes.copy()
     copy.update({
         cast(Nodes, "ordered_list"): add(

--- a/prosemirror/test_builder/__init__.py
+++ b/prosemirror/test_builder/__init__.py
@@ -14,7 +14,7 @@ nodes.update({
     "doc": {
         "content": "block+",
         "attrs": {"meta": {"default": None}},
-    }
+    },
 })
 
 test_schema: Schema[Any, Any] = Schema({

--- a/prosemirror/test_builder/build.py
+++ b/prosemirror/test_builder/build.py
@@ -1,5 +1,6 @@
 # type: ignore
 
+import contextlib
 import re
 from collections.abc import Callable
 from typing import Any
@@ -82,10 +83,8 @@ def block(type, attrs):
         return node
 
     if type.is_leaf:
-        try:
+        with contextlib.suppress(ValueError):
             result.flat = [type.create(attrs)]
-        except ValueError:
-            pass
 
     return result
 

--- a/prosemirror/test_builder/build.py
+++ b/prosemirror/test_builder/build.py
@@ -5,8 +5,8 @@ import re
 from collections.abc import Callable
 from typing import Any
 
-from prosemirror.model import Node, Schema
-from prosemirror.utils import JSONDict
+from prosemirror.model import Node, NodeType, Schema
+from prosemirror.utils import Attrs, JSONDict
 
 NO_TAG = Node.tag = {}
 
@@ -60,11 +60,7 @@ def flatten(
     return result, tag
 
 
-def id(x):
-    return x
-
-
-def block(type, attrs):
+def block(type: NodeType, attrs: Attrs | None = None):
     def result(*args):
         my_attrs = attrs
         if (
@@ -76,7 +72,7 @@ def block(type, attrs):
         ):
             my_attrs.update(args[0])
             args = args[1:]
-        nodes, tag = flatten(type.schema, args, id)
+        nodes, tag = flatten(type.schema, args, lambda x: x)
         node = type.create(my_attrs, nodes)
         if tag != NO_TAG:
             node.tag = tag
@@ -89,7 +85,7 @@ def block(type, attrs):
     return result
 
 
-def mark(type, attrs):
+def mark(type: NodeType, attrs: Attrs):
     def result(*args):
         my_attrs = attrs.copy()
         if (
@@ -114,7 +110,7 @@ def mark(type, attrs):
     return result
 
 
-def builders(schema, names):
+def builders(schema: Schema[Any, Any], names):
     result = {"schema": schema}
     for name in schema.nodes:
         result[name] = block(schema.nodes[name], {})

--- a/prosemirror/test_builder/build.py
+++ b/prosemirror/test_builder/build.py
@@ -1,7 +1,8 @@
 # type: ignore
 
 import re
-from typing import Any, Callable, Dict, List, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 from prosemirror.model import Node, Schema
 from prosemirror.utils import JSONDict
@@ -11,9 +12,9 @@ NO_TAG = Node.tag = {}
 
 def flatten(
     schema: Schema[Any, Any],
-    children: List[Union[Node, JSONDict, str]],
+    children: list[Node | JSONDict | str],
     f: Callable[[Node], Node],
-) -> Tuple[List[Node], Dict[str, int]]:
+) -> tuple[list[Node], dict[str, int]]:
     result, pos, tag = [], 0, NO_TAG
 
     for child in children:
@@ -68,7 +69,7 @@ def block(type, attrs):
         if (
             args
             and args[0]
-            and not isinstance(args[0], (str, Node))
+            and not isinstance(args[0], str | Node)
             and not getattr(args[0], "flat", None)
             and "flat" not in args[0]
         ):
@@ -95,7 +96,7 @@ def mark(type, attrs):
         if (
             args
             and args[0]
-            and not isinstance(args[0], (str, Node))
+            and not isinstance(args[0], str | Node)
             and not getattr(args[0], "flat", None)
             and "flat" not in args[0]
         ):

--- a/prosemirror/transform/attr_step.py
+++ b/prosemirror/transform/attr_step.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from prosemirror.model import Fragment, Node, Schema, Slice
 from prosemirror.transform.map import Mappable, StepMap
@@ -37,7 +37,7 @@ class AttrStep(Step):
         assert node_at_pos is not None
         return AttrStep(self.pos, self.attr, node_at_pos.attrs[self.attr])
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         pos = mapping.map_result(self.pos, 1)
         return None if pos.deleted_after else AttrStep(pos.pos, self.attr, self.value)
 
@@ -50,9 +50,7 @@ class AttrStep(Step):
         }
 
     @staticmethod
-    def from_json(
-        schema: Schema[Any, Any], json_data: Union[JSONDict, str]
-    ) -> "AttrStep":
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> "AttrStep":
         if isinstance(json_data, str):
             import json
 

--- a/prosemirror/transform/attr_step.py
+++ b/prosemirror/transform/attr_step.py
@@ -59,7 +59,8 @@ class AttrStep(Step):
         if not isinstance(json_data["pos"], int) or not isinstance(
             json_data["attr"], str
         ):
-            raise ValueError("Invalid input for AttrStep.from_json")
+            msg = "Invalid input for AttrStep.from_json"
+            raise ValueError(msg)
         return AttrStep(json_data["pos"], json_data["attr"], json_data["value"])
 
 

--- a/prosemirror/transform/attr_step.py
+++ b/prosemirror/transform/attr_step.py
@@ -57,7 +57,8 @@ class AttrStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["pos"], int) or not isinstance(
-            json_data["attr"], str
+            json_data["attr"],
+            str,
         ):
             msg = "Invalid input for AttrStep.from_json"
             raise ValueError(msg)

--- a/prosemirror/transform/doc_attr_step.py
+++ b/prosemirror/transform/doc_attr_step.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from prosemirror.model import Node, Schema
 from prosemirror.transform.map import Mappable, StepMap
@@ -26,7 +26,7 @@ class DocAttrStep(Step):
     def invert(self, doc: Node) -> Step:
         return DocAttrStep(self.attr, doc.attrs[self.attr])
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         return self
 
     def to_json(self) -> JSONDict:
@@ -39,9 +39,7 @@ class DocAttrStep(Step):
         return json_data
 
     @staticmethod
-    def from_json(
-        schema: Schema[Any, Any], json_data: Union[JSONDict, str]
-    ) -> "DocAttrStep":
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> "DocAttrStep":
         if isinstance(json_data, str):
             import json
 

--- a/prosemirror/transform/doc_attr_step.py
+++ b/prosemirror/transform/doc_attr_step.py
@@ -46,7 +46,8 @@ class DocAttrStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["attr"], str):
-            raise ValueError("Invalid input for DocAttrStep.from_json")
+            msg = "Invalid input for DocAttrStep.from_json"
+            raise ValueError(msg)
         return DocAttrStep(json_data["attr"], json_data["value"])
 
 

--- a/prosemirror/transform/doc_attr_step.py
+++ b/prosemirror/transform/doc_attr_step.py
@@ -7,7 +7,7 @@ from prosemirror.utils import JSON, JSONDict
 
 
 class DocAttrStep(Step):
-    def __init__(self, attr: str, value: JSON):
+    def __init__(self, attr: str, value: JSON) -> None:
         super().__init__()
         self.attr = attr
         self.value = value

--- a/prosemirror/transform/map.py
+++ b/prosemirror/transform/map.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Callable, ClassVar, List, Literal, Optional, Union, overload
+from collections.abc import Callable
+from typing import ClassVar, Literal, overload
 
 lower16 = 0xFFFF
 factor16 = 2**16
@@ -24,9 +25,7 @@ DEL_SIDE = 8
 
 
 class MapResult:
-    def __init__(
-        self, pos: int, del_info: int = 0, recover: Optional[int] = None
-    ) -> None:
+    def __init__(self, pos: int, del_info: int = 0, recover: int | None = None) -> None:
         self.pos = pos
         self.del_info = del_info
         self.recover = recover
@@ -67,7 +66,7 @@ class Mappable(metaclass=abc.ABCMeta):
 class StepMap(Mappable):
     empty: ClassVar["StepMap"]
 
-    def __init__(self, ranges: List[int], inverted: bool = False) -> None:
+    def __init__(self, ranges: list[int], inverted: bool = False) -> None:
         # prosemirror-transform overrides the constructor to return the
         # StepMap.empty singleton when ranges are empty.
         # It is not easy to do in Python, and the intent of that is to make sure
@@ -95,7 +94,7 @@ class StepMap(Mappable):
     @overload
     def _map(self, pos: int, assoc: int, simple: Literal[False]) -> MapResult: ...
 
-    def _map(self, pos: int, assoc: int, simple: bool) -> Union[MapResult, int]:
+    def _map(self, pos: int, assoc: int, simple: bool) -> MapResult | int:
         diff = 0
         old_index = 2 if self.inverted else 1
         new_index = 1 if self.inverted else 2
@@ -177,17 +176,17 @@ StepMap.empty = StepMap([])
 class Mapping(Mappable):
     def __init__(
         self,
-        maps: Optional[List[StepMap]] = None,
-        mirror: Optional[List[int]] = None,
-        from_: Optional[int] = None,
-        to: Optional[int] = None,
+        maps: list[StepMap] | None = None,
+        mirror: list[int] | None = None,
+        from_: int | None = None,
+        to: int | None = None,
     ) -> None:
         self.maps = maps or []
         self.from_ = from_ or 0
         self.to = len(self.maps) if to is None else to
         self.mirror = mirror
 
-    def slice(self, from_: int = 0, to: Optional[int] = None) -> "Mapping":
+    def slice(self, from_: int = 0, to: int | None = None) -> "Mapping":
         if to is None:
             to = len(self.maps)
         return Mapping(self.maps, self.mirror, from_, to)
@@ -197,7 +196,7 @@ class Mapping(Mappable):
             self.maps[:], (self.mirror[:] if self.mirror else None), self.from_, self.to
         )
 
-    def append_map(self, map: StepMap, mirrors: Optional[int] = None) -> None:
+    def append_map(self, map: StepMap, mirrors: int | None = None) -> None:
         self.maps.append(map)
         self.to = len(self.maps)
         if mirrors is not None:
@@ -214,7 +213,7 @@ class Mapping(Mappable):
                 (start_size + mirr) if (mirr is not None and mirr < i) else None,
             )
 
-    def get_mirror(self, n: int) -> Optional[int]:
+    def get_mirror(self, n: int) -> int | None:
         if self.mirror:
             for i in range(len(self.mirror)):
                 if (self.mirror[i]) == n:
@@ -258,7 +257,7 @@ class Mapping(Mappable):
     @overload
     def _map(self, pos: int, assoc: int, simple: Literal[False]) -> MapResult: ...
 
-    def _map(self, pos: int, assoc: int, simple: bool) -> Union[MapResult, int]:
+    def _map(self, pos: int, assoc: int, simple: bool) -> MapResult | int:
         del_info = 0
 
         i = self.from_

--- a/prosemirror/transform/map.py
+++ b/prosemirror/transform/map.py
@@ -193,7 +193,10 @@ class Mapping(Mappable):
 
     def copy(self) -> "Mapping":
         return Mapping(
-            self.maps[:], (self.mirror[:] if self.mirror else None), self.from_, self.to
+            self.maps[:],
+            (self.mirror[:] if self.mirror else None),
+            self.from_,
+            self.to,
         )
 
     def append_map(self, map: StepMap, mirrors: int | None = None) -> None:

--- a/prosemirror/transform/mark_step.py
+++ b/prosemirror/transform/mark_step.py
@@ -89,7 +89,8 @@ class AddMarkStep(Step):
         if not isinstance(json_data["from"], int) or not isinstance(
             json_data["to"], int
         ):
-            raise ValueError("Invalid input for AddMarkStep.from_json")
+            msg = "Invalid input for AddMarkStep.from_json"
+            raise ValueError(msg)
         return AddMarkStep(
             json_data["from"],
             json_data["to"],
@@ -160,7 +161,8 @@ class RemoveMarkStep(Step):
         if not isinstance(json_data["from"], int) or not isinstance(
             json_data["to"], int
         ):
-            raise ValueError("Invalid input for RemoveMarkStep.from_json")
+            msg = "Invalid input for RemoveMarkStep.from_json"
+            raise ValueError(msg)
         return RemoveMarkStep(
             json_data["from"],
             json_data["to"],
@@ -219,7 +221,8 @@ class AddNodeMarkStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["pos"], int):
-            raise ValueError("Invalid input for AddNodeMarkStep.from_json")
+            msg = "Invalid input for AddNodeMarkStep.from_json"
+            raise ValueError(msg)
         return AddNodeMarkStep(
             json_data["pos"], schema.mark_from_json(cast(JSONDict, json_data["mark"]))
         )
@@ -273,7 +276,8 @@ class RemoveNodeMarkStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["pos"], int):
-            raise ValueError("Invalid input for RemoveNodeMarkStep.from_json")
+            msg = "Invalid input for RemoveNodeMarkStep.from_json"
+            raise ValueError(msg)
         return RemoveNodeMarkStep(
             json_data["pos"], schema.mark_from_json(cast(JSONDict, json_data["mark"]))
         )

--- a/prosemirror/transform/mark_step.py
+++ b/prosemirror/transform/mark_step.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional, Union, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from prosemirror.model import Fragment, Mark, Node, Schema, Slice
 from prosemirror.transform.map import Mappable
@@ -34,7 +35,7 @@ class AddMarkStep(Step):
         from__ = doc.resolve(self.from_)
         parent = from__.node(from__.shared_depth(self.to))
 
-        def iteratee(node: Node, parent: Optional[Node], i: int) -> Node:
+        def iteratee(node: Node, parent: Node | None, i: int) -> Node:
             if parent and (
                 not node.is_atom or not parent.type.allows_mark_type(self.mark.type)
             ):
@@ -48,17 +49,17 @@ class AddMarkStep(Step):
         )
         return StepResult.from_replace(doc, self.from_, self.to, slice)
 
-    def invert(self, doc: Optional[Node] = None) -> Step:
+    def invert(self, doc: Node | None = None) -> Step:
         return RemoveMarkStep(self.from_, self.to, self.mark)
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         from_ = mapping.map_result(self.from_, 1)
         to = mapping.map_result(self.to, -1)
         if (from_.deleted and to.deleted) or from_.pos > to.pos:
             return None
         return AddMarkStep(from_.pos, to.pos, self.mark)
 
-    def merge(self, other: Step) -> Optional[Step]:
+    def merge(self, other: Step) -> Step | None:
         if (
             isinstance(other, AddMarkStep)
             and other.mark.eq(self.mark)
@@ -79,9 +80,7 @@ class AddMarkStep(Step):
         }
 
     @staticmethod
-    def from_json(
-        schema: Schema[Any, Any], json_data: Union[JSONDict, str]
-    ) -> "AddMarkStep":
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> "AddMarkStep":
         if isinstance(json_data, str):
             import json
 
@@ -111,7 +110,7 @@ class RemoveMarkStep(Step):
     def apply(self, doc: Node) -> StepResult:
         old_slice = doc.slice(self.from_, self.to)
 
-        def iteratee(node: Node, parent: Optional[Node], i: int) -> Node:
+        def iteratee(node: Node, parent: Node | None, i: int) -> Node:
             return node.mark(self.mark.remove_from_set(node.marks))
 
         slice = Slice(
@@ -121,17 +120,17 @@ class RemoveMarkStep(Step):
         )
         return StepResult.from_replace(doc, self.from_, self.to, slice)
 
-    def invert(self, doc: Optional[Node] = None) -> Step:
+    def invert(self, doc: Node | None = None) -> Step:
         return AddMarkStep(self.from_, self.to, self.mark)
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         from_ = mapping.map_result(self.from_, 1)
         to = mapping.map_result(self.to, -1)
         if (from_.deleted and to.deleted) or (from_.pos > to.pos):
             return None
         return RemoveMarkStep(from_.pos, to.pos, self.mark)
 
-    def merge(self, other: Step) -> Optional[Step]:
+    def merge(self, other: Step) -> Step | None:
         if (
             isinstance(other, RemoveMarkStep)
             and (other.mark.eq(self.mark))
@@ -152,7 +151,7 @@ class RemoveMarkStep(Step):
         }
 
     @staticmethod
-    def from_json(schema: Schema[Any, Any], json_data: Union[JSONDict, str]) -> Step:
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> Step:
         if isinstance(json_data, str):
             import json
 
@@ -201,7 +200,7 @@ class AddNodeMarkStep(Step):
                 return AddNodeMarkStep(self.pos, self.mark)
         return RemoveNodeMarkStep(self.pos, self.mark)
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         pos = mapping.map_result(self.pos, 1)
         return None if pos.deleted_after else AddNodeMarkStep(pos.pos, self.mark)
 
@@ -213,7 +212,7 @@ class AddNodeMarkStep(Step):
         }
 
     @staticmethod
-    def from_json(schema: Schema[Any, Any], json_data: Union[JSONDict, str]) -> Step:
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> Step:
         if isinstance(json_data, str):
             import json
 
@@ -255,7 +254,7 @@ class RemoveNodeMarkStep(Step):
             return self
         return AddNodeMarkStep(self.pos, self.mark)
 
-    def map(self, mapping: Mappable) -> Optional[Step]:
+    def map(self, mapping: Mappable) -> Step | None:
         pos = mapping.map_result(self.pos, 1)
         return None if pos.deleted_after else RemoveNodeMarkStep(pos.pos, self.mark)
 
@@ -267,7 +266,7 @@ class RemoveNodeMarkStep(Step):
         }
 
     @staticmethod
-    def from_json(schema: Schema[Any, Any], json_data: Union[JSONDict, str]) -> Step:
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> Step:
         if isinstance(json_data, str):
             import json
 

--- a/prosemirror/transform/mark_step.py
+++ b/prosemirror/transform/mark_step.py
@@ -67,7 +67,9 @@ class AddMarkStep(Step):
             and self.to >= other.from_
         ):
             return AddMarkStep(
-                min(self.from_, other.from_), max(self.to, other.to), self.mark
+                min(self.from_, other.from_),
+                max(self.to, other.to),
+                self.mark,
             )
         return None
 
@@ -87,7 +89,8 @@ class AddMarkStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["from"], int) or not isinstance(
-            json_data["to"], int
+            json_data["to"],
+            int,
         ):
             msg = "Invalid input for AddMarkStep.from_json"
             raise ValueError(msg)
@@ -139,7 +142,9 @@ class RemoveMarkStep(Step):
             and self.to >= other.from_
         ):
             return RemoveMarkStep(
-                min(self.from_, other.from_), max(self.to, other.to), self.mark
+                min(self.from_, other.from_),
+                max(self.to, other.to),
+                self.mark,
             )
         return None
 
@@ -159,7 +164,8 @@ class RemoveMarkStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["from"], int) or not isinstance(
-            json_data["to"], int
+            json_data["to"],
+            int,
         ):
             msg = "Invalid input for RemoveMarkStep.from_json"
             raise ValueError(msg)
@@ -224,7 +230,8 @@ class AddNodeMarkStep(Step):
             msg = "Invalid input for AddNodeMarkStep.from_json"
             raise ValueError(msg)
         return AddNodeMarkStep(
-            json_data["pos"], schema.mark_from_json(cast(JSONDict, json_data["mark"]))
+            json_data["pos"],
+            schema.mark_from_json(cast(JSONDict, json_data["mark"])),
         )
 
 
@@ -242,7 +249,9 @@ class RemoveNodeMarkStep(Step):
         if not node:
             return StepResult.fail("No node at mark step's position")
         updated = node.type.create(
-            node.attrs, None, self.mark.remove_from_set(node.marks)
+            node.attrs,
+            None,
+            self.mark.remove_from_set(node.marks),
         )
         return StepResult.from_replace(
             doc,
@@ -279,7 +288,8 @@ class RemoveNodeMarkStep(Step):
             msg = "Invalid input for RemoveNodeMarkStep.from_json"
             raise ValueError(msg)
         return RemoveNodeMarkStep(
-            json_data["pos"], schema.mark_from_json(cast(JSONDict, json_data["mark"]))
+            json_data["pos"],
+            schema.mark_from_json(cast(JSONDict, json_data["mark"])),
         )
 
 

--- a/prosemirror/transform/replace.py
+++ b/prosemirror/transform/replace.py
@@ -345,7 +345,7 @@ class Fitter:
             )
 
     def must_move_inline(self) -> int:
-        if not self.to_.parent.is_text_block:
+        if not self.to_.parent.is_textblock:
             return -1
         top = self.frontier[self.depth]
 
@@ -359,7 +359,7 @@ class Fitter:
             return cast(_CloseLevel | None, level)
 
         if (
-            not top.type.is_text_block
+            not top.type.is_textblock
             or not content_after_fits(
                 self.to_, self.to_.depth, top.type, top.match, False
             )

--- a/prosemirror/transform/replace.py
+++ b/prosemirror/transform/replace.py
@@ -118,7 +118,7 @@ class Fitter:
         placed_size = self.placed.size - self.depth - self.from__.depth
         from__ = self.from__
         to_ = self.close(
-            self.to_ if move_inline < 0 else from__.doc.resolve(move_inline)
+            self.to_ if move_inline < 0 else from__.doc.resolve(move_inline),
         )
         if not to_:
             return None
@@ -162,11 +162,14 @@ class Fitter:
 
         for pass_ in [1, 2]:
             for slice_depth in range(
-                start_depth if pass_ == 1 else self.unplaced.open_start, -1, -1
+                start_depth if pass_ == 1 else self.unplaced.open_start,
+                -1,
+                -1,
             ):
                 if slice_depth:
                     parent = content_at(
-                        self.unplaced.content, slice_depth - 1
+                        self.unplaced.content,
+                        slice_depth - 1,
                     ).first_child
                     assert parent
                     fragment = parent.content
@@ -186,7 +189,8 @@ class Fitter:
                             match.match_type(first.type)
                             or (
                                 inject := match.fill_before(
-                                    Fragment.from_(first), False
+                                    Fragment.from_(first),
+                                    False,
                                 )
                             )
                         )
@@ -297,7 +301,7 @@ class Fitter:
                         next_.mark(type_.allowed_marks(next_.marks)),
                         open_start if taken == 1 else 0,
                         open_end_count if taken == fragment.child_count else -1,
-                    )
+                    ),
                 )
 
         to_end = taken == fragment.child_count
@@ -325,7 +329,7 @@ class Fitter:
             node = cur.last_child
             assert node is not None
             self.frontier.append(
-                _FrontierItem(node.type, node.content_match_at(node.child_count))
+                _FrontierItem(node.type, node.content_match_at(node.child_count)),
             )
             cur = node.content
 
@@ -361,7 +365,11 @@ class Fitter:
         if (
             not top.type.is_textblock
             or not content_after_fits(
-                self.to_, self.to_.depth, top.type, top.match, False
+                self.to_,
+                self.to_.depth,
+                top.type,
+                top.match,
+                False,
             )
             or (
                 self.to_.depth == self.depth
@@ -430,7 +438,9 @@ class Fitter:
         assert top_match is not None
         top.match = top_match
         self.placed = add_to_fragment(
-            self.placed, self.depth, Fragment.from_(type_.create(attrs, content))
+            self.placed,
+            self.depth,
+            Fragment.from_(type_.create(attrs, content)),
         )
         self.frontier.append(_FrontierItem(type_, type_.content_match))
 
@@ -531,7 +541,7 @@ def close_fragment(
         fragment = fragment.replace_child(
             0,
             first.copy(
-                close_fragment(first.content, depth + 1, old_open, new_open, first)
+                close_fragment(first.content, depth + 1, old_open, new_open, first),
             ),
         )
     if depth > new_open:
@@ -543,7 +553,8 @@ def close_fragment(
         matched_fragment = match.match_fragment(start)
         assert matched_fragment is not None
         matched_fragment_fill_before = matched_fragment.fill_before(
-            Fragment.empty, True
+            Fragment.empty,
+            True,
         )
         assert matched_fragment_fill_before is not None
         fragment = start.append(matched_fragment_fill_before)

--- a/prosemirror/transform/replace_step.py
+++ b/prosemirror/transform/replace_step.py
@@ -8,7 +8,11 @@ from prosemirror.utils import JSONDict
 
 class ReplaceStep(Step):
     def __init__(
-        self, from_: int, to: int, slice: Slice, structure: bool | None = None
+        self,
+        from_: int,
+        to: int,
+        slice: Slice,
+        structure: bool | None = None,
     ) -> None:
         super().__init__()
         self.from_ = from_
@@ -26,7 +30,9 @@ class ReplaceStep(Step):
 
     def invert(self, doc: Node) -> "ReplaceStep":
         return ReplaceStep(
-            self.from_, self.from_ + self.slice.size, doc.slice(self.from_, self.to)
+            self.from_,
+            self.from_ + self.slice.size,
+            doc.slice(self.from_, self.to),
         )
 
     def map(self, mapping: Mappable) -> Optional["ReplaceStep"]:
@@ -53,7 +59,10 @@ class ReplaceStep(Step):
                     other.slice.open_end,
                 )
             return ReplaceStep(
-                self.from_, self.to + (other.to - other.from_), slice, self.structure
+                self.from_,
+                self.to + (other.to - other.from_),
+                slice,
+                self.structure,
             )
         elif (
             other.to == self.from_
@@ -93,7 +102,8 @@ class ReplaceStep(Step):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not isinstance(json_data["from"], int) or not isinstance(
-            json_data["to"], int
+            json_data["to"],
+            int,
         ):
             msg = "Invlid input for ReplaceStep.from_json"
             raise ValueError(msg)
@@ -160,7 +170,8 @@ class ReplaceAroundStep(Step):
             self.from_ + self.insert,
             self.from_ + self.insert + gap,
             doc.slice(self.from_, self.to).remove_between(
-                self.gap_from - self.from_, self.gap_to - self.from_
+                self.gap_from - self.from_,
+                self.gap_to - self.from_,
             ),
             self.gap_from - self.from_,
             self.structure,
@@ -174,7 +185,13 @@ class ReplaceAroundStep(Step):
         if (from_.deleted and to.deleted) or gap_from < from_.pos or gap_to > to.pos:
             return None
         return ReplaceAroundStep(
-            from_.pos, to.pos, gap_from, gap_to, self.slice, self.insert, self.structure
+            from_.pos,
+            to.pos,
+            gap_from,
+            gap_to,
+            self.slice,
+            self.insert,
+            self.structure,
         )
 
     def to_json(self) -> JSONDict:
@@ -200,7 +217,8 @@ class ReplaceAroundStep(Step):
 
     @staticmethod
     def from_json(
-        schema: Schema[Any, Any], json_data: JSONDict | str
+        schema: Schema[Any, Any],
+        json_data: JSONDict | str,
     ) -> "ReplaceAroundStep":
         if isinstance(json_data, str):
             import json

--- a/prosemirror/transform/replace_step.py
+++ b/prosemirror/transform/replace_step.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, cast
 
 from prosemirror.model import Node, Schema, Slice
 from prosemirror.transform.map import Mappable, StepMap
@@ -8,7 +8,7 @@ from prosemirror.utils import JSONDict
 
 class ReplaceStep(Step):
     def __init__(
-        self, from_: int, to: int, slice: Slice, structure: Optional[bool] = None
+        self, from_: int, to: int, slice: Slice, structure: bool | None = None
     ) -> None:
         super().__init__()
         self.from_ = from_
@@ -86,9 +86,7 @@ class ReplaceStep(Step):
         return json_data
 
     @staticmethod
-    def from_json(
-        schema: Schema[Any, Any], json_data: Union[JSONDict, str]
-    ) -> "ReplaceStep":
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> "ReplaceStep":
         if isinstance(json_data, str):
             import json
 
@@ -101,7 +99,7 @@ class ReplaceStep(Step):
         return ReplaceStep(
             json_data["from"],
             json_data["to"],
-            Slice.from_json(schema, cast(Optional[JSONDict], json_data.get("slice"))),
+            Slice.from_json(schema, cast(JSONDict | None, json_data.get("slice"))),
             bool(json_data.get("structure")),
         )
 
@@ -118,7 +116,7 @@ class ReplaceAroundStep(Step):
         gap_to: int,
         slice: Slice,
         insert: int,
-        structure: Optional[bool] = None,
+        structure: bool | None = None,
     ) -> None:
         super().__init__()
         self.from_ = from_
@@ -201,7 +199,7 @@ class ReplaceAroundStep(Step):
 
     @staticmethod
     def from_json(
-        schema: Schema[Any, Any], json_data: Union[JSONDict, str]
+        schema: Schema[Any, Any], json_data: JSONDict | str
     ) -> "ReplaceAroundStep":
         if isinstance(json_data, str):
             import json
@@ -221,7 +219,7 @@ class ReplaceAroundStep(Step):
             json_data["to"],
             json_data["gapFrom"],
             json_data["gapTo"],
-            Slice.from_json(schema, cast(Optional[JSONDict], json_data.get("slice"))),
+            Slice.from_json(schema, cast(JSONDict | None, json_data.get("slice"))),
             json_data["insert"],
             bool(json_data.get("structure")),
         )

--- a/prosemirror/transform/replace_step.py
+++ b/prosemirror/transform/replace_step.py
@@ -95,7 +95,8 @@ class ReplaceStep(Step):
         if not isinstance(json_data["from"], int) or not isinstance(
             json_data["to"], int
         ):
-            raise ValueError("Invlid input for ReplaceStep.from_json")
+            msg = "Invlid input for ReplaceStep.from_json"
+            raise ValueError(msg)
         return ReplaceStep(
             json_data["from"],
             json_data["to"],
@@ -213,7 +214,8 @@ class ReplaceAroundStep(Step):
             or not isinstance(json_data["gapTo"], int)
             or not isinstance(json_data["insert"], int)
         ):
-            raise ValueError("Invlid input for ReplaceAroundStep.from_json")
+            msg = "Invlid input for ReplaceAroundStep.from_json"
+            raise ValueError(msg)
         return ReplaceAroundStep(
             json_data["from"],
             json_data["to"],

--- a/prosemirror/transform/step.py
+++ b/prosemirror/transform/step.py
@@ -39,16 +39,19 @@ class Step(metaclass=abc.ABCMeta):
             json_data = cast(JSONDict, json.loads(json_data))
 
         if not json_data or not json_data.get("stepType"):
-            raise ValueError("Invalid inpit for Step.from_json")
+            msg = "Invalid inpit for Step.from_json"
+            raise ValueError(msg)
         type = STEPS_BY_ID.get(cast(str, json_data["stepType"]))
         if not type:
-            raise ValueError(f'no step type {json_data["stepType"]} defined')
+            msg = f'no step type {json_data["stepType"]} defined'
+            raise ValueError(msg)
         return type.from_json(schema, json_data)
 
 
 def step_json_id(id: str, step_class: type[StepSubclass]) -> type[StepSubclass]:
     if id in STEPS_BY_ID:
-        raise ValueError(f"Duplicated JSON ID for step type: {id}")
+        msg = f"Duplicated JSON ID for step type: {id}"
+        raise ValueError(msg)
 
     STEPS_BY_ID[id] = step_class
     step_class.json_id = id

--- a/prosemirror/transform/step.py
+++ b/prosemirror/transform/step.py
@@ -1,12 +1,12 @@
 import abc
-from typing import Any, Dict, Literal, Optional, Type, TypeVar, Union, cast, overload
+from typing import Any, Literal, Optional, TypeVar, cast, overload
 
 from prosemirror.model import Node, ReplaceError, Schema, Slice
 from prosemirror.transform.map import Mappable, StepMap
 from prosemirror.utils import JSONDict
 
 # like a registry
-STEPS_BY_ID: Dict[str, Type["Step"]] = {}
+STEPS_BY_ID: dict[str, type["Step"]] = {}
 StepSubclass = TypeVar("StepSubclass", bound="Step")
 
 
@@ -32,7 +32,7 @@ class Step(metaclass=abc.ABCMeta):
     def to_json(self) -> JSONDict: ...
 
     @staticmethod
-    def from_json(schema: Schema[Any, Any], json_data: Union[JSONDict, str]) -> "Step":
+    def from_json(schema: Schema[Any, Any], json_data: JSONDict | str) -> "Step":
         if isinstance(json_data, str):
             import json
 
@@ -46,7 +46,7 @@ class Step(metaclass=abc.ABCMeta):
         return type.from_json(schema, json_data)
 
 
-def step_json_id(id: str, step_class: Type[StepSubclass]) -> Type[StepSubclass]:
+def step_json_id(id: str, step_class: type[StepSubclass]) -> type[StepSubclass]:
     if id in STEPS_BY_ID:
         raise ValueError(f"Duplicated JSON ID for step type: {id}")
 
@@ -63,7 +63,7 @@ class StepResult:
     @overload
     def __init__(self, doc: None, failed: str) -> None: ...
 
-    def __init__(self, doc: Optional[Node], failed: Optional[str]) -> None:
+    def __init__(self, doc: Node | None, failed: str | None) -> None:
         self.doc = doc
         self.failed = failed
 

--- a/prosemirror/transform/structure.py
+++ b/prosemirror/transform/structure.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypedDict, Union
+from typing import TypedDict
 
 from prosemirror.model import ContentMatch, Node, NodeRange, NodeType, Slice
 from prosemirror.utils import Attrs
@@ -10,7 +10,7 @@ def can_cut(node: Node, start: int, end: int) -> bool:
     return False
 
 
-def lift_target(range_: NodeRange) -> Optional[int]:
+def lift_target(range_: NodeRange) -> int | None:
     parent = range_.parent
     content = parent.content.cut_by_index(range_.start_index, range_.end_index)
     depth = range_.depth
@@ -33,15 +33,15 @@ def lift_target(range_: NodeRange) -> Optional[int]:
 
 class NodeTypeWithAttrs(TypedDict):
     type: NodeType
-    attrs: Optional[Attrs]
+    attrs: Attrs | None
 
 
 def find_wrapping(
     range_: NodeRange,
     node_type: NodeType,
-    attrs: Optional[Attrs] = None,
-    inner_range: Optional[NodeRange] = None,
-) -> Optional[List[NodeTypeWithAttrs]]:
+    attrs: Attrs | None = None,
+    inner_range: NodeRange | None = None,
+) -> list[NodeTypeWithAttrs] | None:
     if inner_range is None:
         inner_range = range_
 
@@ -67,9 +67,7 @@ def with_attrs(type: NodeType) -> NodeTypeWithAttrs:
     return NodeTypeWithAttrs(type=type, attrs=None)
 
 
-def find_wrapping_outside(
-    range_: NodeRange, type: NodeType
-) -> Optional[List[NodeType]]:
+def find_wrapping_outside(range_: NodeRange, type: NodeType) -> list[NodeType] | None:
     parent = range_.parent
     start_index = range_.start_index
     end_index = range_.end_index
@@ -80,7 +78,7 @@ def find_wrapping_outside(
     return around if parent.can_replace_with(start_index, end_index, outer) else None
 
 
-def find_wrapping_inside(range_: NodeRange, type: NodeType) -> Optional[List[NodeType]]:
+def find_wrapping_inside(range_: NodeRange, type: NodeType) -> list[NodeType] | None:
     parent = range_.parent
     start_index = range_.start_index
     end_index = range_.end_index
@@ -91,7 +89,7 @@ def find_wrapping_inside(range_: NodeRange, type: NodeType) -> Optional[List[Nod
         return None
 
     last_type = inside[-1] if len(inside) else type
-    inner_match: Optional[ContentMatch] = last_type.content_match
+    inner_match: ContentMatch | None = last_type.content_match
     i = start_index
 
     while inner_match and i < end_index:
@@ -113,14 +111,14 @@ def can_change_type(doc: Node, pos: int, type: NodeType) -> bool:
 def can_split(
     doc: Node,
     pos: int,
-    depth: Optional[int] = None,
-    types_after: Optional[List[NodeTypeWithAttrs]] = None,
+    depth: int | None = None,
+    types_after: list[NodeTypeWithAttrs] | None = None,
 ) -> bool:
     if depth is None:
         depth = 1
     pos_ = doc.resolve(pos)
     base = pos_.depth - depth
-    inner_type: Union[NodeTypeWithAttrs, Node, None] = None
+    inner_type: NodeTypeWithAttrs | Node | None = None
 
     if types_after:
         inner_type = types_after[-1]
@@ -165,7 +163,7 @@ def can_split(
             rest = rest.replace_child(
                 0, override_child["type"].create(override_child.get("attrs"))
             )
-        after: Union[NodeTypeWithAttrs, Node, None] = None
+        after: NodeTypeWithAttrs | Node | None = None
         if types_after and len(types_after) > i:
             after = types_after[i]
         if not after:
@@ -193,7 +191,7 @@ def can_split(
     )
 
 
-def can_join(doc: Node, pos: int) -> Optional[bool]:
+def can_join(doc: Node, pos: int) -> bool | None:
     pos_ = doc.resolve(pos)
     index = pos_.index()
     return (
@@ -203,13 +201,13 @@ def can_join(doc: Node, pos: int) -> Optional[bool]:
     )
 
 
-def joinable(a: Optional[Node], b: Optional[Node]) -> bool:
+def joinable(a: Node | None, b: Node | None) -> bool:
     if a and b and not a.is_leaf:
         return a.can_append(b)
     return False
 
 
-def join_point(doc: Node, pos: int, dir: int = -1) -> Optional[int]:
+def join_point(doc: Node, pos: int, dir: int = -1) -> int | None:
     pos_ = doc.resolve(pos)
     for d in range(pos_.depth, -1, -1):
         before = None
@@ -239,7 +237,7 @@ def join_point(doc: Node, pos: int, dir: int = -1) -> Optional[int]:
     return None
 
 
-def insert_point(doc: Node, pos: int, node_type: NodeType) -> Optional[int]:
+def insert_point(doc: Node, pos: int, node_type: NodeType) -> int | None:
     pos_ = doc.resolve(pos)
     if pos_.parent.can_replace_with(pos_.index(), pos_.index(), node_type):
         return pos
@@ -261,7 +259,7 @@ def insert_point(doc: Node, pos: int, node_type: NodeType) -> Optional[int]:
     return None
 
 
-def drop_point(doc: Node, pos: int, slice: Slice) -> Optional[int]:
+def drop_point(doc: Node, pos: int, slice: Slice) -> int | None:
     pos_ = doc.resolve(pos)
     if not slice.content.size:
         return pos

--- a/prosemirror/transform/structure.py
+++ b/prosemirror/transform/structure.py
@@ -121,7 +121,8 @@ def can_split(
     pos_ = doc.resolve(pos)
     base = pos_.depth - depth
     inner_type: NodeTypeWithAttrs = cast(
-        NodeTypeWithAttrs, (types_after and types_after[-1]) or pos_.parent
+        NodeTypeWithAttrs,
+        (types_after and types_after[-1]) or pos_.parent,
     )
 
     if (
@@ -129,7 +130,7 @@ def can_split(
         or pos_.parent.type.spec.get("isolating")
         or not pos_.parent.can_replace(pos_.index(), pos_.parent.child_count)
         or not inner_type.type.valid_content(
-            pos_.parent.content.cut_by_index(pos_.index(), pos_.parent.child_count)
+            pos_.parent.content.cut_by_index(pos_.index(), pos_.parent.child_count),
         )
     ):
         return False
@@ -147,14 +148,16 @@ def can_split(
         if types_after and len(types_after) > i + 1:
             override_child = types_after[i + 1]
             rest = rest.replace_child(
-                0, override_child.type.create(override_child.attrs)
+                0,
+                override_child.type.create(override_child.attrs),
             )
         after: NodeTypeWithAttrs = cast(
             NodeTypeWithAttrs,
             (types_after and len(types_after) > i and types_after[i]) or node,
         )
         if not node.can_replace(
-            index + 1, node.child_count
+            index + 1,
+            node.child_count,
         ) or not after.type.valid_content(rest):
             return False
         d -= 1
@@ -162,7 +165,9 @@ def can_split(
     index = pos_.index_after(base)
     base_type = types_after[0] if types_after else None
     return pos_.node(base).can_replace_with(
-        index, index, base_type.type if base_type else pos_.node(base + 1).type
+        index,
+        index,
+        base_type.type if base_type else pos_.node(base + 1).type,
     )
 
 
@@ -259,10 +264,12 @@ def drop_point(doc: Node, pos: int, slice: Slice) -> int | None:
             else:
                 assert content.first_child is not None
                 wrapping = parent.content_match_at(insert_pos).find_wrapping(
-                    content.first_child.type
+                    content.first_child.type,
                 )
                 fits = wrapping is not None and parent.can_replace_with(
-                    insert_pos, insert_pos, wrapping[0]
+                    insert_pos,
+                    insert_pos,
+                    wrapping[0],
                 )
             if fits:
                 if bias == 0:

--- a/prosemirror/transform/structure.py
+++ b/prosemirror/transform/structure.py
@@ -137,16 +137,15 @@ def can_split(
         ):
             return False
 
-    elif isinstance(inner_type, dict):
-        if (
-            base < 0
-            or pos_.parent.type.spec.get("isolating")
-            or not pos_.parent.can_replace(pos_.index(), pos_.parent.child_count)
-            or not inner_type["type"].valid_content(
-                pos_.parent.content.cut_by_index(pos_.index(), pos_.parent.child_count)
-            )
-        ):
-            return False
+    elif isinstance(inner_type, dict) and (
+        base < 0
+        or pos_.parent.type.spec.get("isolating")
+        or not pos_.parent.can_replace(pos_.index(), pos_.parent.child_count)
+        or not inner_type["type"].valid_content(
+            pos_.parent.content.cut_by_index(pos_.index(), pos_.parent.child_count)
+        )
+    ):
+        return False
 
     d = pos_.depth - 1
     i = depth - 2
@@ -158,7 +157,7 @@ def can_split(
             return False
         rest = node.content.cut_by_index(index, node.child_count)
 
-        if types_after and len(types_after) > i:
+        if types_after and len(types_after) > i + 1:
             override_child = types_after[i + 1]
             rest = rest.replace_child(
                 0, override_child["type"].create(override_child.get("attrs"))
@@ -169,7 +168,7 @@ def can_split(
         if not after:
             after = node
 
-        if isinstance(after, dict):
+        if isinstance(after, dict):  # noqa: SIM102
             if not node.can_replace(index + 1, node.child_count) or not after[
                 "type"
             ].valid_content(rest):

--- a/prosemirror/transform/structure.py
+++ b/prosemirror/transform/structure.py
@@ -264,7 +264,7 @@ def drop_point(doc: Node, pos: int, slice: Slice) -> int | None:
     if not slice.content.size:
         return pos
     content = slice.content
-    for i in range(slice.open_start):
+    for _i in range(slice.open_start):
         assert content.first_child is not None
         content = content.first_child.content
     pass_ = 1

--- a/prosemirror/transform/structure.py
+++ b/prosemirror/transform/structure.py
@@ -200,7 +200,7 @@ def join_point(doc: Node, pos: int, dir: int = -1) -> int | None:
             after = pos_.node(d + 1)
         if (
             before
-            and not before.is_text_block
+            and not before.is_textblock
             and joinable(before, after)
             and pos_.node(d).can_replace(index, index + 1)
         ):

--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -477,10 +477,11 @@ class Transform:
             if content.size:
                 match = wrappers[i].type.content_match.match_fragment(content)
                 if not match or not match.valid_end:
-                    raise TransformError(
+                    msg = (
                         "Wrapper type given to Transform.wrap does not form valid "
                         "content of its parent wrapper"
                     )
+                    raise TransformError(msg)
             content = Fragment.from_(
                 wrappers[i].type.create(wrappers[i].attrs, content)
             )
@@ -503,7 +504,8 @@ class Transform:
         if to is None:
             to = from_
         if not type.is_textblock:
-            raise ValueError("Type given to set_block_type should be a textblock")
+            msg = "Type given to set_block_type should be a textblock"
+            raise ValueError(msg)
         map_from = len(self.steps)
 
         def iteratee(
@@ -548,14 +550,16 @@ class Transform:
     ) -> "Transform":
         node = self.doc.node_at(pos)
         if not node:
-            raise ValueError("No node at given position")
+            msg = "No node at given position"
+            raise ValueError(msg)
         if not type:
             type = node.type
         new_node = type.create(attrs, None, marks or node.marks)
         if node.is_leaf:
             return self.replace_with(pos, pos + node.node_size, new_node)
         if not type.valid_content(node.content):
-            raise ValueError(f"Invalid content for node type {type.name}")
+            msg = f"Invalid content for node type {type.name}"
+            raise ValueError(msg)
         return self.step(
             ReplaceAroundStep(
                 pos,
@@ -582,7 +586,8 @@ class Transform:
             node = self.doc.node_at(pos)
 
             if not node:
-                raise ValueError(f"No node at position {pos}")
+                msg = f"No node at position {pos}"
+                raise ValueError(msg)
 
             mark_in_set = mark.is_in_set(node.marks)
 

--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -227,14 +227,15 @@ class Transform:
                             slice = Slice(
                                 Fragment.from_(
                                     parent_type.schema.text(
-                                        " ", parent_type.allowed_marks(child.marks)
-                                    )
+                                        " ",
+                                        parent_type.allowed_marks(child.marks),
+                                    ),
                                 ),
                                 0,
                                 0,
                             )
                         repl_steps.append(
-                            ReplaceStep(cur + m.start(), cur + m.end(), slice)
+                            ReplaceStep(cur + m.start(), cur + m.end(), slice),
                         )
                         m = newline.search(child.text, m.end())
             cur = end
@@ -329,7 +330,7 @@ class Transform:
             assert left_node is not None
             def_ = defines_content(left_node.type)
             if def_ and not left_node.same_markup(
-                from__.node(abs(preferred_target) - 1)
+                from__.node(abs(preferred_target) - 1),
             ):
                 preferred_depth = d
             elif def_ or not left_node.type.is_textblock:
@@ -357,7 +358,11 @@ class Transform:
                         to_.after(target_depth) if expand else to,
                         Slice(
                             close_fragment(
-                                slice.content, 0, slice.open_start, open_depth, None
+                                slice.content,
+                                0,
+                                slice.open_start,
+                                open_depth,
+                                None,
                             ),
                             open_depth,
                             slice.open_end,
@@ -403,7 +408,8 @@ class Transform:
             if depth > 0 and (
                 last
                 or from__.node(depth - 1).can_replace(
-                    from__.index(depth - 1), to_.index_after(depth - 1)
+                    from__.index(depth - 1),
+                    to_.index_after(depth - 1),
                 )
             ):
                 return self.delete(from__.before(depth), to_.after(depth))
@@ -465,11 +471,13 @@ class Transform:
                 Slice(before.append(after), open_start, open_end),
                 before.size - open_start,
                 True,
-            )
+            ),
         )
 
     def wrap(
-        self, range_: NodeRange, wrappers: list[structure.NodeTypeWithAttrs]
+        self,
+        range_: NodeRange,
+        wrappers: list[structure.NodeTypeWithAttrs],
     ) -> "Transform":
         content = Fragment.empty
         i = len(wrappers) - 1
@@ -483,15 +491,21 @@ class Transform:
                     )
                     raise TransformError(msg)
             content = Fragment.from_(
-                wrappers[i].type.create(wrappers[i].attrs, content)
+                wrappers[i].type.create(wrappers[i].attrs, content),
             )
             i -= 1
         start = range_.start
         end = range_.end
         return self.step(
             ReplaceAroundStep(
-                start, end, start, end, Slice(content, 0, 0), len(wrappers), True
-            )
+                start,
+                end,
+                start,
+                end,
+                Slice(content, 0, 0),
+                len(wrappers),
+                True,
+            ),
         )
 
     def set_block_type(
@@ -509,13 +523,18 @@ class Transform:
         map_from = len(self.steps)
 
         def iteratee(
-            node: "Node", pos: int, parent: Optional["Node"], i: int
+            node: "Node",
+            pos: int,
+            parent: Optional["Node"],
+            i: int,
         ) -> bool | None:
             if (
                 node.is_textblock
                 and not node.has_markup(type, attrs)
                 and structure.can_change_type(
-                    self.doc, self.mapping.slice(map_from).map(pos), type
+                    self.doc,
+                    self.mapping.slice(map_from).map(pos),
+                    type,
                 )
             ):
                 self.clear_incompatible(self.mapping.slice(map_from).map(pos, 1), type)
@@ -529,11 +548,13 @@ class Transform:
                         start_m + 1,
                         end_m - 1,
                         Slice(
-                            Fragment.from_(type.create(attrs, None, node.marks)), 0, 0
+                            Fragment.from_(type.create(attrs, None, node.marks)),
+                            0,
+                            0,
                         ),
                         1,
                         True,
-                    )
+                    ),
                 )
                 return False
             return None
@@ -569,7 +590,7 @@ class Transform:
                 Slice(Fragment.from_(new_node), 0, 0),
                 1,
                 True,
-            )
+            ),
         )
 
     def set_node_attribute(self, pos: int, attr: str, value: JSON) -> "Transform":
@@ -619,12 +640,12 @@ class Transform:
             after = Fragment.from_(
                 type_after.type.create(type_after.attrs, after)
                 if type_after
-                else pos_.node(d).copy(after)
+                else pos_.node(d).copy(after),
             )
             d -= 1
             i -= 1
         return self.step(
-            ReplaceStep(pos, pos, Slice(before.append(after), depth, depth), True)
+            ReplaceStep(pos, pos, Slice(before.append(after), depth, depth), True),
         )
 
     def join(self, pos: int, depth: int = 1) -> "Transform":

--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -475,14 +475,14 @@ class Transform:
         i = len(wrappers) - 1
         while i >= 0:
             if content.size:
-                match = wrappers[i]["type"].content_match.match_fragment(content)
+                match = wrappers[i].type.content_match.match_fragment(content)
                 if not match or not match.valid_end:
                     raise TransformError(
                         "Wrapper type given to Transform.wrap does not form valid "
                         "content of its parent wrapper"
                     )
             content = Fragment.from_(
-                wrappers[i]["type"].create(wrappers[i].get("attrs"), content)
+                wrappers[i].type.create(wrappers[i].attrs, content)
             )
             i -= 1
         start = range_.start
@@ -612,7 +612,7 @@ class Transform:
             if types_after and len(types_after) > i:
                 type_after = types_after[i]
             after = Fragment.from_(
-                type_after["type"].create(type_after.get("attrs"), after)
+                type_after.type.create(type_after.attrs, after)
                 if type_after
                 else pos_.node(d).copy(after)
             )

--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -332,7 +332,7 @@ class Transform:
                 from__.node(abs(preferred_target) - 1)
             ):
                 preferred_depth = d
-            elif def_ or not left_node.type.is_text_block:
+            elif def_ or not left_node.type.is_textblock:
                 break
             d -= 1
 
@@ -502,7 +502,7 @@ class Transform:
     ) -> "Transform":
         if to is None:
             to = from_
-        if not type.is_text_block:
+        if not type.is_textblock:
             raise ValueError("Type given to set_block_type should be a textblock")
         map_from = len(self.steps)
 
@@ -510,7 +510,7 @@ class Transform:
             node: "Node", pos: int, parent: Optional["Node"], i: int
         ) -> bool | None:
             if (
-                node.is_text_block
+                node.is_textblock
                 and not node.has_markup(type, attrs)
                 and structure.can_change_type(
                     self.doc, self.mapping.slice(map_from).map(pos), type

--- a/prosemirror/utils.py
+++ b/prosemirror/utils.py
@@ -1,11 +1,10 @@
-from typing import Mapping, Sequence, Union
-
-from typing_extensions import TypeAlias
+from collections.abc import Mapping, Sequence
+from typing import TypeAlias
 
 JSONDict: TypeAlias = Mapping[str, "JSON"]
 JSONList: TypeAlias = Sequence["JSON"]
 
-JSON: TypeAlias = Union[JSONDict, JSONList, str, int, float, bool, None]
+JSON: TypeAlias = JSONDict | JSONList | str | int | float | bool | None
 
 Attrs: TypeAlias = JSONDict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "RUF", "UP", "B"]
+select = ["E", "F", "W", "I", "RUF", "UP", "B", "I", "SIM"]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "RUF"]
+select = ["E", "F", "W", "I", "RUF", "UP"]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "prosemirror"
 version = "0.4.0"
 description = "Python implementation of core ProseMirror modules for collaborative editing"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Samuel Cormier-Iijima", email = "sam@fellow.co" },
     { name = "Shen Li", email = "dustet@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "RUF", "UP", "B", "I", "SIM"]
+select = ["E", "F", "W", "I", "RUF", "UP", "B", "I", "SIM", "PT"]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 license = { text = "BSD-3-Clause" }
 keywords = ["prosemirror", "collaborative", "editing"]
-dependencies = ["typing-extensions>=4.4", "lxml>=5.2", "cssselect>=1.2"]
+dependencies = ["typing-extensions>=4.1", "lxml>=4.9", "cssselect>=1.2"]
 
 [project.optional-dependencies]
 dev = [
@@ -24,7 +24,7 @@ dev = [
     "mypy~=1.9",
     "pytest~=8.1",
     "pytest-cov~=5.0",
-    "ruff~=0.3",
+    "ruff~=0.4",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "RUF", "UP"]
+select = ["E", "F", "W", "I", "RUF", "UP", "B"]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "RUF", "UP", "B", "I", "SIM", "PT"]
+select = ["B", "E", "EM", "F", "I", "I", "PT", "RSE", "RUF", "SIM", "UP", "W"]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
 
 [tool.ruff.lint]
 select = [
+    "ANN",
     "B",
     "COM",
     "E",
@@ -44,7 +45,12 @@ select = [
     "UP",
     "W",
 ]
+ignore = ["COM812"]
 preview = true
+
+[tool.ruff.lint.per-file-ignores]
+"prosemirror/test_builder/**" = ["ANN"]
+"tests/**" = ["ANN"]
 
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,21 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["B", "E", "EM", "F", "I", "I", "PT", "RSE", "RUF", "SIM", "UP", "W"]
+select = [
+    "B",
+    "COM",
+    "E",
+    "EM",
+    "F",
+    "I",
+    "I",
+    "PT",
+    "RSE",
+    "RUF",
+    "SIM",
+    "UP",
+    "W",
+]
 preview = true
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ select = [
     "F",
     "I",
     "I",
+    "N",
     "PT",
     "RSE",
     "RUF",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def ist():
     def ist(a, b=None, key=None):
         if key is None:

--- a/tests/prosemirror_model/tests/test_content.py
+++ b/tests/prosemirror_model/tests/test_content.py
@@ -30,7 +30,7 @@ def match(expr, types):
 
 
 @pytest.mark.parametrize(
-    "expr,types,valid",
+    ("expr", "types", "valid"),
     [
         ("", "", True),
         ("", "image", False),
@@ -100,7 +100,7 @@ def test_match_type(expr, types, valid):
 
 
 @pytest.mark.parametrize(
-    "expr,before,after,result",
+    ("expr", "before", "after", "result"),
     [
         (
             "paragraph horizontal_rule paragraph",
@@ -218,7 +218,7 @@ def test_fill_before(expr, before, after, result):
 
 
 @pytest.mark.parametrize(
-    "expr,before,mid,after,left,right",
+    ("expr", "before", "mid", "after", "left", "right"),
     [
         (
             "paragraph horizontal_rule paragraph horizontal_rule paragraph",

--- a/tests/prosemirror_model/tests/test_content.py
+++ b/tests/prosemirror_model/tests/test_content.py
@@ -287,7 +287,7 @@ def test_fill3_before(expr, before, mid, after, left, right):
     b = False
     if a:
         b = content.match_fragment(
-            before.content.append(a).append(mid.content)
+            before.content.append(a).append(mid.content),
         ).fill_before(after.content, True)
     if left:
         left = Node.from_json(schema, left)

--- a/tests/prosemirror_model/tests/test_diff.py
+++ b/tests/prosemirror_model/tests/test_diff.py
@@ -12,7 +12,7 @@ strong = out["strong"]
 
 
 @pytest.mark.parametrize(
-    "a,b",
+    ("a", "b"),
     [
         (
             doc(p("a", em("b")), p("hello"), blockquote(h1("bye"))),
@@ -39,7 +39,7 @@ def test_find_diff_start(a, b):
 
 
 @pytest.mark.parametrize(
-    "a,b",
+    ("a", "b"),
     [
         (
             doc(p("a", em("b")), p("hello"), blockquote(h1("bye"))),

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -57,7 +57,7 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
                 p(
                     "a ",
                     a({"href": "foo"}, "big ", a({"href": "bar"}, "nested"), " link"),
-                )
+                ),
             ),
             '<p>a <a href="foo">big </a><a href="bar">nested</a>'
             '<a href="foo"> link</a></p>',
@@ -65,7 +65,8 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
         (
             "it can represent an unordered list",
             doc(
-                ul(li(p("one")), li(p("two")), li(p("three", strong("!")))), p("after")
+                ul(li(p("one")), li(p("two")), li(p("three", strong("!")))),
+                p("after"),
             ),
             "<ul><li><p>one</p></li><li><p>two</p></li><li><p>three"
             "<strong>!</strong></p></li></ul><p>after</p>",
@@ -73,7 +74,8 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
         (
             "it can represent an ordered list",
             doc(
-                ol(li(p("one")), li(p("two")), li(p("three", strong("!")))), p("after")
+                ol(li(p("one")), li(p("two")), li(p("three", strong("!")))),
+                p("after"),
             ),
             "<ol><li><p>one</p></li><li><p>two</p></li><li><p>three"
             "<strong>!</strong></p></li></ol><p>after</p>",
@@ -169,7 +171,10 @@ def test_html_is_escaped():
             {
                 "type": "doc",
                 "content": [
-                    {"type": "paragraph", "content": [{"type": "text", "text": "test"}]}
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "test"}],
+                    },
                 ],
             },
         ),
@@ -189,7 +194,7 @@ def test_html_is_escaped():
                                 "text": "some bolded text",
                             },
                         ],
-                    }
+                    },
                 ],
             },
         ),
@@ -247,7 +252,7 @@ def test_html_is_escaped():
                                             "href": "www.google.ca",
                                             "title": None,
                                         },
-                                    }
+                                    },
                                 ],
                                 "text": "google",
                             },
@@ -264,7 +269,7 @@ def test_html_is_escaped():
                                     "alt": None,
                                     "title": None,
                                 },
-                            }
+                            },
                         ],
                     },
                     {
@@ -274,7 +279,7 @@ def test_html_is_escaped():
                                 "type": "text",
                                 "marks": [{"type": "strong", "attrs": {}}],
                                 "text": "Hello",
-                            }
+                            },
                         ],
                     },
                     {
@@ -314,9 +319,9 @@ def test_html_is_escaped():
                     {
                         "type": "paragraph",
                         "content": [
-                            {"type": "text", "text": "Testing the result of this"}
+                            {"type": "text", "text": "Testing the result of this"},
                         ],
-                    }
+                    },
                 ],
             },
         ),

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -29,7 +29,7 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
 
 
 @pytest.mark.parametrize(
-    "desc,doc,html",
+    ("desc", "doc", "html"),
     [
         (
             "it can represent simple node",
@@ -119,7 +119,7 @@ def test_serializer_first(doc, html, desc):
 
 
 @pytest.mark.parametrize(
-    "desc,serializer,doc,expect",
+    ("desc", "serializer", "doc", "expect"),
     [
         (
             "it can omit a mark",
@@ -161,7 +161,7 @@ def test_html_is_escaped():
 
 
 @pytest.mark.parametrize(
-    "desc,doc,expect",
+    ("desc", "doc", "expect"),
     [
         (
             "Basic text node",

--- a/tests/prosemirror_model/tests/test_mark.py
+++ b/tests/prosemirror_model/tests/test_mark.py
@@ -44,7 +44,7 @@ custom_strong = custom["strong"].create()
 
 
 @pytest.mark.parametrize(
-    "a,b,res",
+    ("a", "b", "res"),
     [
         ([em_, strong], [em_, strong], True),
         ([em_, strong], [em_, code], False),
@@ -58,7 +58,7 @@ def test_same_set(a, b, res):
 
 
 @pytest.mark.parametrize(
-    "a,b,res",
+    ("a", "b", "res"),
     [
         (link("http://foo"), (link("http://foo")), True),
         (link("http://foo"), link("http://bar"), False),
@@ -171,7 +171,7 @@ class TestResolvedPosMarks:
     )
 
     @pytest.mark.parametrize(
-        "doc,mark,result",
+        ("doc", "mark", "result"),
         [
             (doc(p(em("fo<a>o"))), em_, True),
             (doc(p(em("fo<a>o"))), strong, False),
@@ -185,7 +185,7 @@ class TestResolvedPosMarks:
         assert mark.is_in_set(doc.resolve(doc.tag["a"]).marks()) is result
 
     @pytest.mark.parametrize(
-        "a,b",
+        ("a", "b"),
         [
             (custom_doc.resolve(4).marks(), [custom_strong]),
             (custom_doc.resolve(3).marks(), [remark1, custom_strong]),

--- a/tests/prosemirror_model/tests/test_mark.py
+++ b/tests/prosemirror_model/tests/test_mark.py
@@ -116,7 +116,7 @@ def test_remove_form_set(ist):
         Mark.same_set(
             link("http://foo", "title").remove_from_set([link("http://foo")]),
             [link("http://foo")],
-        )
+        ),
     )
 
 

--- a/tests/prosemirror_model/tests/test_node.py
+++ b/tests/prosemirror_model/tests/test_node.py
@@ -73,7 +73,7 @@ class TestToString:
         )
         assert str(f) == "<custom_text, custom_hard_break, custom_text>"
 
-    def test_should_respect_custom_leafText_spec(self):
+    def test_should_respect_custom_leaf_text_spec(self):
         contact = custom_schema.nodes["contact"].create_checked({
             "name": "Bob",
             "email": "bob@example.com",
@@ -194,7 +194,7 @@ class TestTextBetween:
         text = d.text_between(0, d.content.size, "", leaf_text)
         assert text == "foo<image><break>"
 
-    def test_works_with_leafText(self):
+    def test_works_with_leaf_text(self):
         d = custom_schema.nodes["doc"].create_checked(
             {},
             [
@@ -212,7 +212,7 @@ class TestTextBetween:
         )
         assert d.text_between(0, d.content.size) == "Hello Alice <alice@example.com>"
 
-    def test_should_ignore_leafText_spec_when_passing_a_custom_leaf_text(self):
+    def test_should_ignore_leaf_text_spec_when_passing_a_custom_leaf_text(self):
         d = custom_schema.nodes["doc"].create_checked(
             {},
             [

--- a/tests/prosemirror_model/tests/test_node.py
+++ b/tests/prosemirror_model/tests/test_node.py
@@ -128,15 +128,16 @@ class TestBetween:
             nonlocal i
 
             if i == len(nodes):
-                raise Exception(f"More nodes iterated than list ({node.type.name})")
+                msg = f"More nodes iterated than list ({node.type.name})"
+                raise Exception(msg)
             compare = node.text if node.is_text else node.type.name
             if compare != nodes[i]:
-                raise Exception(f"Expected {nodes[i]!r}, got {compare!r}")
+                msg = f"Expected {nodes[i]!r}, got {compare!r}"
+                raise Exception(msg)
             i += 1
             if not node.is_text and doc.node_at(pos) != node:
-                raise Exception(
-                    f"Pos {pos} does not point at node {node!r} {doc.nodeAt(pos)!r}"
-                )
+                msg = f"Pos {pos} does not point at node {node!r} {doc.nodeAt(pos)!r}"
+                raise Exception(msg)
 
         doc.nodes_between(doc.tag["a"], doc.tag["b"], iteratee)
 

--- a/tests/prosemirror_model/tests/test_node.py
+++ b/tests/prosemirror_model/tests/test_node.py
@@ -18,7 +18,8 @@ hr = out["hr"]
 img = out["img"]
 
 custom_schema: Schema[
-    Literal["doc", "paragraph", "text", "contact", "hard_break"], str
+    Literal["doc", "paragraph", "text", "contact", "hard_break"],
+    str,
 ] = Schema({
     "nodes": {
         "doc": {"content": "paragraph+"},
@@ -78,7 +79,8 @@ class TestToString:
             "email": "bob@example.com",
         })
         paragraph = custom_schema.nodes["paragraph"].create_checked(
-            {}, [custom_schema.text("Hello "), contact]
+            {},
+            [custom_schema.text("Hello "), contact],
         )
 
         assert contact.text_content, "Bob <bob@example.com>"
@@ -100,8 +102,9 @@ class TestCut:
         self.cut(
             doc(
                 blockquote(
-                    ul(li(p("a"), p("b<a>c")), li(p("d")), "<b>", li(p("e"))), p("3")
-                )
+                    ul(li(p("a"), p("b<a>c")), li(p("d")), "<b>", li(p("e"))),
+                    p("3"),
+                ),
             ),
             doc(blockquote(ul(li(p("c")), li(p("d"))))),
         )
@@ -165,7 +168,7 @@ class TestBetween:
                     em("bar", img, strong("baz"), br),
                     "quux",
                     code("xy<b>z"),
-                )
+                ),
             ),
             "paragraph",
             "foo",
@@ -204,7 +207,7 @@ class TestTextBetween:
                             "email": "alice@example.com",
                         }),
                     ],
-                )
+                ),
             ],
         )
         assert d.text_between(0, d.content.size) == "Hello Alice <alice@example.com>"
@@ -222,7 +225,7 @@ class TestTextBetween:
                             "email": "alice@example.com",
                         }),
                     ],
-                )
+                ),
             ],
         )
         assert (
@@ -282,5 +285,5 @@ class TestToJSON:
 
     def test_serialize_nested_nodes(self):
         self.round_trip(
-            doc(blockquote(ul(li(p("a"), p("b")), li(p(img))), p("c")), p("d"))
+            doc(blockquote(ul(li(p("a"), p("b")), li(p(img))), p("c")), p("d")),
         )

--- a/tests/prosemirror_model/tests/test_resolve.py
+++ b/tests/prosemirror_model/tests/test_resolve.py
@@ -31,7 +31,7 @@ _p2 = {"node": _blk["node"].child(0), "start": 6, "end": 10}
             [_doc, _blk, _p2, 4, "ef", None],
             [_doc, _blk, 6, _p2["node"], None],
             [_doc, 12, _blk["node"], None],
-        ])
+        ]),
     ),
 )
 def test_node_resolve(pos, exp):

--- a/tests/prosemirror_model/tests/test_resolve.py
+++ b/tests/prosemirror_model/tests/test_resolve.py
@@ -15,7 +15,7 @@ _p2 = {"node": _blk["node"].child(0), "start": 6, "end": 10}
 
 
 @pytest.mark.parametrize(
-    "pos,exp",
+    ("pos", "exp"),
     list(
         enumerate([
             [_doc, 0, None, _p1["node"]],
@@ -60,7 +60,7 @@ def test_node_resolve(pos, exp):
 
 
 @pytest.mark.parametrize(
-    "pos,result",
+    ("pos", "result"),
     [
         (0, ":0"),
         (1, "paragraph_0:0"),
@@ -71,13 +71,13 @@ def test_resolvedpos_str(pos, result):
     assert str(test_doc.resolve(pos)) == result
 
 
-@pytest.fixture
+@pytest.fixture()
 def doc_for_pos_at_index():
     return doc(blockquote(p("one"), blockquote(p("two ", em("three")), p("four"))))
 
 
 @pytest.mark.parametrize(
-    "index,depth,pos",
+    ("index", "depth", "pos"),
     [
         (0, None, 8),
         (1, None, 12),

--- a/tests/prosemirror_model/tests/test_slice.py
+++ b/tests/prosemirror_model/tests/test_slice.py
@@ -12,7 +12,7 @@ blockquote = out["blockquote"]
 
 
 @pytest.mark.parametrize(
-    "doc,expect,open_start,open_end",
+    ("doc", "expect", "open_start", "open_end"),
     [
         (doc(p("hello<b> world")), doc(p("hello")), 0, 1),
         (doc(p("hello<b>")), doc(p("hello")), 0, 1),

--- a/tests/prosemirror_model/tests/test_slice.py
+++ b/tests/prosemirror_model/tests/test_slice.py
@@ -65,8 +65,10 @@ blockquote = out["blockquote"]
         (
             doc(
                 blockquote(
-                    p("foo<a>bar"), ul(li(p("a")), li(p("b"), "<b>", p("c"))), p("d")
-                )
+                    p("foo<a>bar"),
+                    ul(li(p("a")), li(p("b"), "<b>", p("c"))),
+                    p("d"),
+                ),
             ),
             blockquote(p("bar"), ul(li(p("a")), li(p("b")))),
             1,

--- a/tests/prosemirror_transform/tests/conftest.py
+++ b/tests/prosemirror_transform/tests/conftest.py
@@ -70,15 +70,15 @@ def make_step():
     return _make_step
 
 
-def _make_step(from_, to, val):
+def _make_step(from_: int, to: int, val: str | None) -> Step:
     if val == "+em":
-        return AddMarkStep(from_, to, schema.marks["em"].create)
+        return AddMarkStep(from_, to, schema.marks["em"].create())
     elif val == "-em":
-        return RemoveMarkStep(from_, to, schema.marks["em"].create)
+        return RemoveMarkStep(from_, to, schema.marks["em"].create())
     return ReplaceStep(
         from_,
         to,
-        Slice.empty if val is None else Slice(Fragment.from_(schema.text(val), 0, 0)),
+        Slice.empty if val is None else Slice(Fragment.from_(schema.text(val)), 0, 0),
     )
 
 

--- a/tests/prosemirror_transform/tests/conftest.py
+++ b/tests/prosemirror_transform/tests/conftest.py
@@ -17,7 +17,7 @@ doc = out["doc"]
 p = out["p"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_mapping():
     def t_mapping(mapping, *cases):
         inverted = mapping.invert()
@@ -32,7 +32,7 @@ def test_mapping():
     return t_mapping
 
 
-@pytest.fixture
+@pytest.fixture()
 def make_mapping():
     def mk(*args):
         mapping = Mapping()
@@ -47,7 +47,7 @@ def make_mapping():
     return mk
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_del():
     def t_del(mapping: Mapping, pos: int, side: int, flags: str):
         r = mapping.map_result(pos, side)
@@ -65,7 +65,7 @@ def test_del():
     return t_del
 
 
-@pytest.fixture
+@pytest.fixture()
 def make_step():
     return _make_step
 
@@ -82,7 +82,7 @@ def _make_step(from_, to, val):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_doc():
     return doc(p("foobar"))
 
@@ -90,7 +90,7 @@ def test_doc():
 _test_doc = doc(p("foobar"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_transform():
     def invert(transform):
         out = Transform(transform.doc)

--- a/tests/prosemirror_transform/tests/test_mapping.py
+++ b/tests/prosemirror_transform/tests/test_mapping.py
@@ -2,23 +2,23 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "mapping_info,cases",
+    ("mapping_info", "cases"),
     [
-        [[[2, 0, 4]], [[0, 0], [2, 6], [2, 2, -1], [3, 7]]],
-        [
+        ([[2, 0, 4]], [[0, 0], [2, 6], [2, 2, -1], [3, 7]]),
+        (
             [[2, 4, 0]],
             [[0, 0], [2, 2, -1], [3, 2, 1, True], [6, 2, 1], [6, 2, -1, True], [7, 3]],
-        ],
-        [
+        ),
+        (
             [[2, 4, 4]],
             [[0, 0], [2, 2, 1], [4, 6, 1, True], [4, 2, -1, True], [6, 6, -1], [8, 8]],
-        ],
-        [[[2, 4, 0], [2, 0, 4], {0: 1}], [[0, 0], [2, 2], [4, 4], [6, 6], [7, 7]]],
-        [[[2, 0, 4], [2, 4, 0], {0: 1}], [[0, 0], [2, 2], [3, 3]]],
-        [
+        ),
+        ([[2, 4, 0], [2, 0, 4], {0: 1}], [[0, 0], [2, 2], [4, 4], [6, 6], [7, 7]]),
+        ([[2, 0, 4], [2, 4, 0], {0: 1}], [[0, 0], [2, 2], [3, 3]]),
+        (
             [[2, 4, 0], [1, 0, 1], [3, 0, 4], {0: 2}],
             [[0, 0], [1, 2], [4, 5], [6, 7], [7, 8]],
-        ],
+        ),
     ],
 )
 def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
@@ -26,12 +26,12 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
 
 
 @pytest.mark.parametrize(
-    "mapping_info,pos,side,flags",
+    ("mapping_info", "pos", "side", "flags"),
     [
-        [([0, 2, 0],), 2, -1, "db"],
-        [([0, 2, 0],), 2, 1, "b"],
-        [([0, 2, 2],), 2, -1, "db"],
-        [
+        (([0, 2, 0],), 2, -1, "db"),
+        (([0, 2, 0],), 2, 1, "b"),
+        (([0, 2, 2],), 2, -1, "db"),
+        (
             (
                 [0, 1, 0],
                 [0, 1, 0],
@@ -39,12 +39,12 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             -1,
             "db",
-        ],
-        [([0, 1, 0],), 2, -1, ""],
-        [([2, 2, 0],), 2, -1, "a"],
-        [([2, 2, 0],), 2, 1, "da"],
-        [([2, 2, 2],), 2, 1, "da"],
-        [
+        ),
+        (([0, 1, 0],), 2, -1, ""),
+        (([2, 2, 0],), 2, -1, "a"),
+        (([2, 2, 0],), 2, 1, "da"),
+        (([2, 2, 2],), 2, 1, "da"),
+        (
             (
                 [2, 1, 0],
                 [2, 1, 0],
@@ -52,12 +52,11 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             1,
             "da",
-        ],
-        [([3, 2, 0],), 2, -1, ""],
-        [([0, 4, 0],), 2, -1, "dbax"],
-        [([0, 4, 0],), 2, 1, "dbax"],
-        [([0, 4, 0],), 2, 1, "dbax"],
-        [
+        ),
+        (([3, 2, 0],), 2, -1, ""),
+        (([0, 4, 0],), 2, -1, "dbax"),
+        (([0, 4, 0],), 2, 1, "dbax"),
+        (
             (
                 [0, 1, 0],
                 [4, 1, 0],
@@ -66,8 +65,8 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             1,
             "dbax",
-        ],
-        [
+        ),
+        (
             (
                 [4, 1, 0],
                 [0, 1, 0],
@@ -75,8 +74,8 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             -1,
             "",
-        ],
-        [
+        ),
+        (
             (
                 [2, 1, 0],
                 [0, 2, 0],
@@ -84,8 +83,8 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             -1,
             "dba",
-        ],
-        [
+        ),
+        (
             (
                 [2, 1, 0],
                 [0, 1, 0],
@@ -93,8 +92,8 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             -1,
             "a",
-        ],
-        [
+        ),
+        (
             (
                 [3, 1, 0],
                 [0, 2, 0],
@@ -102,7 +101,7 @@ def test_all_mapping_cases(mapping_info, cases, test_mapping, make_mapping):
             2,
             -1,
             "db",
-        ],
+        ),
     ],
 )
 def test_all_del_cases(mapping_info, pos, side, flags, test_del, make_mapping):

--- a/tests/prosemirror_transform/tests/test_step.py
+++ b/tests/prosemirror_transform/tests/test_step.py
@@ -27,7 +27,7 @@ def no(from1, to1, val1, from2, to2, val2):
 
 
 @pytest.mark.parametrize(
-    "pass_,from1,to1,val1,from2,to2,val2",
+    ("pass_", "from1", "to1", "val1", "from2", "to2", "val2"),
     [
         (yes, 2, 2, "a", 3, 3, "b"),
         (yes, 2, 2, "a", 2, 2, "b"),

--- a/tests/prosemirror_transform/tests/test_step.py
+++ b/tests/prosemirror_transform/tests/test_step.py
@@ -20,8 +20,8 @@ def no(from1, to1, val1, from2, to2, val2):
     def inner():
         step1 = _make_step(from1, to1, val1)
         step2 = _make_step(from2, to2, val2)
-        with pytest.raises(ValueError):
-            step1.merge(step2)
+        merged = step1.merge(step2)
+        assert merged is None
 
     return inner
 
@@ -51,4 +51,4 @@ def no(from1, to1, val1, from2, to2, val2):
     ],
 )
 def test_all_cases(pass_, from1, to1, val1, from2, to2, val2):
-    pass_(from1, to1, val1, from2, to2, val2)
+    pass_(from1, to1, val1, from2, to2, val2)()

--- a/tests/prosemirror_transform/tests/test_step.py
+++ b/tests/prosemirror_transform/tests/test_step.py
@@ -10,7 +10,7 @@ def yes(from1, to1, val1, from2, to2, val2):
         merged = step1.merge(step2)
         assert merged
         assert merged.apply(_test_doc).doc.eq(
-            step2.apply(step1.apply(_test_doc).doc).doc
+            step2.apply(step1.apply(_test_doc).doc).doc,
         )
 
     return inner

--- a/tests/prosemirror_transform/tests/test_structure.py
+++ b/tests/prosemirror_transform/tests/test_structure.py
@@ -2,6 +2,7 @@ import pytest
 
 from prosemirror.model import Schema, Slice
 from prosemirror.transform import Transform, can_split, find_wrapping, lift_target
+from prosemirror.transform.structure import NodeTypeWithAttrs
 
 schema = Schema({
     "nodes": {
@@ -94,7 +95,10 @@ class TestCanSplit:
     )
     def test_can_split(self, pass_, pos, depth, after):
         res = can_split(
-            doc, pos, depth, [{"type": schema.nodes[after]}] if after else None
+            doc,
+            pos,
+            depth,
+            [NodeTypeWithAttrs(type=schema.nodes[after])] if after else None,
         )
         if pass_:
             assert res
@@ -137,7 +141,7 @@ class TestCanSplit:
             ),
             4,
             1,
-            [{"type": s.nodes["scene"]}],
+            [NodeTypeWithAttrs(s.nodes["scene"])],
         )
 
 

--- a/tests/prosemirror_transform/tests/test_structure.py
+++ b/tests/prosemirror_transform/tests/test_structure.py
@@ -263,9 +263,6 @@ class TestFindWrapping:
     ],
 )
 def test_replace(doc, from_, to, content, open_start, open_end, result):
-    if content:
-        slice = Slice(content.content, open_start, open_end)
-    else:
-        slice = Slice.empty
+    slice = Slice(content.content, open_start, open_end) if content else Slice.empty
     tr = Transform(doc).replace(from_, to, slice)
     assert tr.doc.eq(result)

--- a/tests/prosemirror_transform/tests/test_structure.py
+++ b/tests/prosemirror_transform/tests/test_structure.py
@@ -69,7 +69,7 @@ def fill(params, length):
 
 class TestCanSplit:
     @pytest.mark.parametrize(
-        "pass_,pos,depth,after",
+        ("pass_", "pos", "depth", "after"),
         fill(
             [
                 (False, 0),
@@ -147,7 +147,7 @@ class TestCanSplit:
 
 class TestLiftTarget:
     @pytest.mark.parametrize(
-        "pass_,pos",
+        ("pass_", "pos"),
         [(False, 0), (False, 3), (False, 52), (False, 70), (True, 76), (False, 86)],
     )
     def test_lift_target(self, pass_, pos):
@@ -160,7 +160,7 @@ class TestLiftTarget:
 
 class TestFindWrapping:
     @pytest.mark.parametrize(
-        "pass_,pos,end,type",
+        ("pass_", "pos", "end", "type"),
         [
             (True, 0, 92, "sect"),
             (False, 4, 4, "sect"),
@@ -179,7 +179,7 @@ class TestFindWrapping:
 
 
 @pytest.mark.parametrize(
-    "doc,from_,to,content,open_start,open_end,result",
+    ("doc", "from_", "to", "content", "open_start", "open_end", "result"),
     [
         (
             n("doc", n("sect", n("head", t("foo")), n("para", t("bar")))),

--- a/tests/prosemirror_transform/tests/test_structure.py
+++ b/tests/prosemirror_transform/tests/test_structure.py
@@ -42,7 +42,9 @@ doc = n(
             n("head", t("Subsection head")),  # 46
             n("para", t("Subtext")),  # 55
             n(
-                "figure", n("caption", t("Figure caption")), n("figureimage")
+                "figure",
+                n("caption", t("Figure caption")),
+                n("figureimage"),
             ),  # 56  # 72  # 74
             n("quote", n("para", t("!"))),
         ),
@@ -124,7 +126,7 @@ class TestCanSplit:
                 "title": {"content": "text*"},
                 "chapter": {"content": "title scene+"},
                 "scene": {"content": "para+"},
-            }
+            },
         })
         assert not can_split(
             s.node(

--- a/tests/prosemirror_transform/tests/test_trans.py
+++ b/tests/prosemirror_transform/tests/test_trans.py
@@ -4,6 +4,7 @@ from prosemirror.model import Fragment, Schema, Slice
 from prosemirror.test_builder import builders, out
 from prosemirror.test_builder import test_schema as schema
 from prosemirror.transform import Transform, TransformError, find_wrapping, lift_target
+from prosemirror.transform.structure import NodeTypeWithAttrs
 
 doc = out["doc"]
 docMetaOne = out["docMetaOne"]
@@ -333,7 +334,7 @@ def test_join(doc, expect, test_transform):
         (
             doc(h1("hell<a>o!")),
             doc(h1("hell"), p("<a>o!")),
-            [None, [{"type": schema.nodes["paragraph"]}]],
+            [None, [NodeTypeWithAttrs(schema.nodes["paragraph"])]],
         ),
         (doc(blockquote("<a>", p("x"))), "fail", []),
         (doc(blockquote(p("x"), "<a>")), "fail", []),

--- a/tests/prosemirror_transform/tests/test_trans.py
+++ b/tests/prosemirror_transform/tests/test_trans.py
@@ -51,7 +51,9 @@ hr = out["hr"]
         ),
         (
             doc(
-                p("before"), blockquote(p("the variable is called <a>i<b>")), p("after")
+                p("before"),
+                blockquote(p("the variable is called <a>i<b>")),
+                p("after"),
             ),
             schema.mark("code"),
             doc(
@@ -83,8 +85,10 @@ def test_does_not_remove_non_excluded_marks_of_the_same_type():
     })
     tr = Transform(
         schema.node(
-            "doc", None, schema.text("hi", [schema.mark("comment", {"id": 10})])
-        )
+            "doc",
+            None,
+            schema.text("hi", [schema.mark("comment", {"id": 10})]),
+        ),
     )
     tr.add_mark(0, 2, schema.mark("comment", {"id": 20}))
     assert len(tr.doc.first_child.marks) == 2
@@ -100,7 +104,7 @@ def test_can_remote_multiple_excluded_marks():
             "doc",
             None,
             schema.text("hi", [schema.mark("small1"), schema.mark("small2")]),
-        )
+        ),
     )
     assert len(tr.doc.first_child.marks) == 2
     tr.add_mark(0, 2, schema.mark("big"))
@@ -180,7 +184,7 @@ def test_remove_more_than_one_mark_of_same_type_from_block():
                 "hi",
                 [schema.mark("comment", {"id": 1}), schema.mark("comment", {"id": 2})],
             ),
-        )
+        ),
     )
     assert len(tr.doc.first_child.marks) == 2
     tr.remove_mark(0, 2, schema.marks["comment"])
@@ -255,7 +259,10 @@ def test_delete(doc, expect, test_transform):
     [
         (
             doc(
-                blockquote(p("<before>a")), "<a>", blockquote(p("b")), p("after<after>")
+                blockquote(p("<before>a")),
+                "<a>",
+                blockquote(p("b")),
+                p("after<after>"),
             ),
             doc(blockquote(p("<before>a"), "<a>", p("b")), p("after<after>")),
         ),
@@ -266,12 +273,12 @@ def test_delete(doc, expect, test_transform):
                     blockquote(p("a"), p("b<before>")),
                     "<a>",
                     blockquote(p("c"), p("d<after>")),
-                )
+                ),
             ),
             doc(
                 blockquote(
-                    blockquote(p("a"), p("b<before>"), "<a>", p("c"), p("d<after>"))
-                )
+                    blockquote(p("a"), p("b<before>"), "<a>", p("c"), p("d<after>")),
+                ),
             ),
         ),
         (
@@ -301,7 +308,8 @@ def test_join(doc, expect, test_transform):
         (
             doc(blockquote(blockquote(p("foo<a>bar"))), p("after<1>")),
             doc(
-                blockquote(blockquote(p("foo")), blockquote(p("<a>bar"))), p("after<1>")
+                blockquote(blockquote(p("foo")), blockquote(p("<a>bar"))),
+                p("after<1>"),
             ),
             [2],
         ),
@@ -350,7 +358,9 @@ def test_split(doc, expect, args, test_transform):
         (
             doc(blockquote(p("<before>one"), p("<a>two"), p("<after>three"))),
             doc(
-                blockquote(p("<before>one")), p("<a>two"), blockquote(p("<after>three"))
+                blockquote(p("<before>one")),
+                p("<a>two"),
+                blockquote(p("<after>three")),
             ),
         ),
         (
@@ -379,8 +389,8 @@ def test_split(doc, expect, args, test_transform):
                         p("<3>three"),
                         p("<b>four"),
                         p("<5>five"),
-                    )
-                )
+                    ),
+                ),
             ),
             doc(
                 blockquote(
@@ -389,7 +399,7 @@ def test_split(doc, expect, args, test_transform):
                     p("<3>three"),
                     p("<b>four"),
                     blockquote(p("<5>five")),
-                )
+                ),
             ),
         ),
         (
@@ -404,7 +414,7 @@ def test_split(doc, expect, args, test_transform):
 )
 def test_lift(doc, expect, test_transform):
     range = doc.resolve(doc.tag.get("a")).block_range(
-        doc.resolve(doc.tag.get("b") or doc.tag.get("a"))
+        doc.resolve(doc.tag.get("b") or doc.tag.get("a")),
     )
     tr = Transform(doc).lift(range, lift_target(range))
     test_transform(tr, expect)
@@ -437,14 +447,14 @@ def test_lift(doc, expect, test_transform):
                     li(p("<1>one")),
                     li(p("..."), p("<a>two"), p("<b>three")),
                     li(p("<4>four")),
-                )
+                ),
             ),
             doc(
                 ol(
                     li(p("<1>one")),
                     li(p("..."), ol(li(p("<a>two"), p("<b>three")))),
                     li(p("<4>four")),
-                )
+                ),
             ),
             "ordered_list",
             None,
@@ -459,7 +469,7 @@ def test_lift(doc, expect, test_transform):
 )
 def test_wrap(doc, expect, type, attrs, test_transform):
     range = doc.resolve(doc.tag.get("a")).block_range(
-        doc.resolve(doc.tag.get("b") or doc.tag.get("a"))
+        doc.resolve(doc.tag.get("b") or doc.tag.get("a")),
     )
     tr = Transform(doc).wrap(range, find_wrapping(range, schema.nodes[type], attrs))
     test_transform(tr, expect)
@@ -611,8 +621,14 @@ def test_set_doc_attribute(doc, expect, attr, value, test_transform):
         (
             doc(
                 blockquote(
-                    ul(li(p("a")), li(p("b<a>")), li(p("c")), li(p("<b>d")), li(p("e")))
-                )
+                    ul(
+                        li(p("a")),
+                        li(p("b<a>")),
+                        li(p("c")),
+                        li(p("<b>d")),
+                        li(p("e")),
+                    ),
+                ),
             ),
             None,
             doc(blockquote(ul(li(p("a")), li(p("b<a><b>d")), li(p("e"))))),
@@ -676,8 +692,8 @@ def test_set_doc_attribute(doc, expect, attr, value, test_transform):
         (
             doc(
                 blockquote(
-                    blockquote(p("one"), p("tw<a>o"), p("t<b>hree<3>"), p("four<4>"))
-                )
+                    blockquote(p("one"), p("tw<a>o"), p("t<b>hree<3>"), p("four<4>")),
+                ),
             ),
             doc(ol(li(p("hello<a>world")), li(p("bye"))), p("ne<b>xt")),
             doc(
@@ -688,8 +704,8 @@ def test_set_doc_attribute(doc, expect, attr, value, test_transform):
                         ol(li(p("bye"))),
                         p("ne<b>hree<3>"),
                         p("four<4>"),
-                    )
-                )
+                    ),
+                ),
             ),
         ),
         (
@@ -756,7 +772,9 @@ def test_replace(doc, source, expect, test_transform):
     else:
         slice = source.slice(source.tag.get("a"), source.tag.get("b"))
     tr = Transform(doc).replace(
-        doc.tag.get("a"), doc.tag.get("b") or doc.tag.get("a"), slice
+        doc.tag.get("a"),
+        doc.tag.get("b") or doc.tag.get("a"),
+        slice,
     )
     test_transform(tr, expect)
 
@@ -841,7 +859,7 @@ def test_replacing_in_nodes_with_fixed_content():
             "b": {"content": "inline*"},
             "block": {"content": "a b"},
             "text": {"group": "inline"},
-        }
+        },
     })
 
     doc = s.node(
@@ -879,7 +897,7 @@ class TestTopLevelMarkReplace:
                     ms.node("paragraph", None, [ms.text("hey")], [ms.mark("em")]),
                     ms.node("paragraph", None, [ms.text("ok")], [ms.mark("strong")]),
                 ],
-            )
+            ),
         )
         tr.replace(2, 7, tr.doc.slice(2, 7))
         assert tr.doc.eq(tr.before)
@@ -887,7 +905,7 @@ class TestTopLevelMarkReplace:
     def test_preserves_marks_on_open_slice_block_nodes(self):
         ms = self.ms
         tr = Transform(
-            ms.node("doc", None, [ms.node("paragraph", None, [ms.text("a")])])
+            ms.node("doc", None, [ms.node("paragraph", None, [ms.text("a")])]),
         )
         tr.replace(
             3,
@@ -978,7 +996,7 @@ def test_keeps_isolating_nodes_together():
     })
     doc = s.node("doc", None, [s.node("paragraph", None, [s.text("one")])])
     iso = Fragment.from_(
-        s.node("iso", None, [s.node("paragraph", None, [s.text("two")])])
+        s.node("iso", None, [s.node("paragraph", None, [s.text("two")])]),
     )
     assert (
         Transform(doc)
@@ -992,7 +1010,7 @@ def test_keeps_isolating_nodes_together():
                     s.node("iso", None, [s.node("paragraph", None, [s.text("two")])]),
                     s.node("paragraph", None, [s.text("e")]),
                 ],
-            )
+            ),
         )
     )
     assert (
@@ -1045,7 +1063,9 @@ def test_replace_range(doc, source, expect, test_transform):
     else:
         slice = source.slice(source.tag.get("a"), source.tag.get("b"), True)
     tr = Transform(doc).replace_range(
-        doc.tag.get("a"), doc.tag.get("b") or doc.tag.get("a"), slice
+        doc.tag.get("a"),
+        doc.tag.get("b") or doc.tag.get("a"),
+        slice,
     )
     test_transform(tr, expect)
 
@@ -1069,7 +1089,9 @@ def test_replace_range(doc, source, expect, test_transform):
 )
 def test_replace_range_with(doc, node, expect, test_transform):
     tr = Transform(doc).replace_range_with(
-        doc.tag.get("a"), doc.tag.get("b") or doc.tag.get("a"), node
+        doc.tag.get("a"),
+        doc.tag.get("b") or doc.tag.get("a"),
+        node,
     )
     test_transform(tr, expect)
 
@@ -1101,7 +1123,8 @@ def test_replace_range_with(doc, node, expect, test_transform):
 )
 def test_delete_range(doc, expect, test_transform):
     tr = Transform(doc).delete_range(
-        doc.tag.get("a"), doc.tag.get("b") or doc.tag.get("a")
+        doc.tag.get("a"),
+        doc.tag.get("b") or doc.tag.get("a"),
     )
     test_transform(tr, expect)
 

--- a/tests/prosemirror_transform/tests/test_trans.py
+++ b/tests/prosemirror_transform/tests/test_trans.py
@@ -27,7 +27,7 @@ hr = out["hr"]
 
 
 @pytest.mark.parametrize(
-    "doc,mark,expect",
+    ("doc", "mark", "expect"),
     [
         (
             doc(p("hello <a>there<b>!")),
@@ -108,7 +108,7 @@ def test_can_remote_multiple_excluded_marks():
 
 
 @pytest.mark.parametrize(
-    "doc,mark,expect",
+    ("doc", "mark", "expect"),
     [
         (
             doc(p(em("hello <a>world<b>!"))),
@@ -124,11 +124,6 @@ def test_can_remote_multiple_excluded_marks():
             doc(p(em("one ", strong("<a>two<b>"), " three"))),
             schema.mark("strong"),
             doc(p(em("one two three"))),
-        ),
-        (
-            doc(p("<a>hello ", a("link<b>"))),
-            schema.mark("link", {"href": "foo"}),
-            doc(p("hello link")),
         ),
         (
             doc(p("<a>hello ", a("link<b>"))),
@@ -193,7 +188,7 @@ def test_remove_more_than_one_mark_of_same_type_from_block():
 
 
 @pytest.mark.parametrize(
-    "doc,nodes,expect",
+    ("doc", "nodes", "expect"),
     [
         (
             doc(p("hello<a>there")),
@@ -235,7 +230,7 @@ def test_insert(doc, nodes, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect",
+    ("doc", "expect"),
     [
         (
             doc(p("<1>one"), "<a>", p("tw<2>o"), "<b>", p("<3>three")),
@@ -256,7 +251,7 @@ def test_delete(doc, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect",
+    ("doc", "expect"),
     [
         (
             doc(
@@ -296,7 +291,7 @@ def test_join(doc, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,args",
+    ("doc", "expect", "args"),
     [
         (
             doc(p("<1>a"), p("<2>foo<a>bar<3>"), p("<4>b")),
@@ -350,7 +345,7 @@ def test_split(doc, expect, args, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect",
+    ("doc", "expect"),
     [
         (
             doc(blockquote(p("<before>one"), p("<a>two"), p("<after>three"))),
@@ -416,7 +411,7 @@ def test_lift(doc, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,type,attrs",
+    ("doc", "expect", "type", "attrs"),
     [
         (
             doc(p("one"), p("<a>two"), p("three")),
@@ -471,7 +466,7 @@ def test_wrap(doc, expect, type, attrs, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,node_type,attrs",
+    ("doc", "expect", "node_type", "attrs"),
     [
         (doc(p("am<a> i")), doc(h2("am i")), "heading", {"level": 2}),
         (
@@ -532,7 +527,7 @@ def test_set_block_type_works_after_another_step(test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,type,attrs",
+    ("doc", "expect", "type", "attrs"),
     [
         (doc("<a>", p("foo")), doc(h1("foo")), "heading", {"level": 1}),
         (
@@ -549,7 +544,7 @@ def test_set_node_markup(doc, expect, type, attrs, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,attr,value",
+    ("doc", "expect", "attr", "value"),
     [
         (doc("<a>", h1("foo")), doc(h2("foo")), "level", 2),
         (
@@ -566,7 +561,7 @@ def test_set_node_attribute(doc, expect, attr, value, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect,attr,value",
+    ("doc", "expect", "attr", "value"),
     [
         (doc(h1("foo")), docMetaOne(h1("foo")), "meta", 1),
         (docMetaOne(h1("foo")), docMetaTwo(h1("foo")), "meta", 2),
@@ -579,7 +574,7 @@ def test_set_doc_attribute(doc, expect, attr, value, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,source,expect",
+    ("doc", "source", "expect"),
     [
         (doc(p("hell<a>o y<b>ou")), None, doc(p("hell<a><b>ou"))),
         (doc(p("hell<a>o"), p("y<b>ou")), None, doc(p("hell<a><b>ou"))),
@@ -1008,7 +1003,7 @@ def test_keeps_isolating_nodes_together():
 
 
 @pytest.mark.parametrize(
-    "doc,source,expect",
+    ("doc", "source", "expect"),
     [
         (doc(p("foo<a>b<b>ar")), p("<a>xx<b>"), doc(p("foo<a>xx<b>ar"))),
         (doc(p("<a>")), doc(h1("<a>text<b>")), doc(h1("text"))),
@@ -1056,7 +1051,7 @@ def test_replace_range(doc, source, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,node,expect",
+    ("doc", "node", "expect"),
     [
         (doc(p("fo<a>o")), img(), doc(p("fo", img(), "<a>o"))),
         (doc(p("<a>fo<b>o")), img(), doc(p("<a>", img(), "o"))),
@@ -1080,7 +1075,7 @@ def test_replace_range_with(doc, node, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,expect",
+    ("doc", "expect"),
     [
         (doc(p("fo<a>o"), p("b<b>ar")), doc(p("fo<a><b>ar"))),
         (
@@ -1112,7 +1107,7 @@ def test_delete_range(doc, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,mark,expect",
+    ("doc", "mark", "expect"),
     [
         # adds a mark
         (doc(p("<a>", img())), schema.mark("em"), doc(p("<a>", em(img())))),
@@ -1131,7 +1126,7 @@ def test_add_node_mark(doc, mark, expect, test_transform):
 
 
 @pytest.mark.parametrize(
-    "doc,mark,expect",
+    ("doc", "mark", "expect"),
     [
         # removes a mark
         (doc(p("<a>", em(img()))), schema.mark("em"), doc(p("<a>", img()))),

--- a/tests/prosemirror_transform/tests/test_trans.py
+++ b/tests/prosemirror_transform/tests/test_trans.py
@@ -7,8 +7,8 @@ from prosemirror.transform import Transform, TransformError, find_wrapping, lift
 from prosemirror.transform.structure import NodeTypeWithAttrs
 
 doc = out["doc"]
-docMetaOne = out["docMetaOne"]
-docMetaTwo = out["docMetaTwo"]
+doc_meta_one = out["docMetaOne"]
+doc_meta_two = out["docMetaTwo"]
 blockquote = out["blockquote"]
 pre = out["pre"]
 h1 = out["h1"]
@@ -573,9 +573,9 @@ def test_set_node_attribute(doc, expect, attr, value, test_transform):
 @pytest.mark.parametrize(
     ("doc", "expect", "attr", "value"),
     [
-        (doc(h1("foo")), docMetaOne(h1("foo")), "meta", 1),
-        (docMetaOne(h1("foo")), docMetaTwo(h1("foo")), "meta", 2),
-        (docMetaTwo(h1("foo")), doc(h1("foo")), "meta", None),
+        (doc(h1("foo")), doc_meta_one(h1("foo")), "meta", 1),
+        (doc_meta_one(h1("foo")), doc_meta_two(h1("foo")), "meta", 2),
+        (doc_meta_two(h1("foo")), doc(h1("foo")), "meta", None),
     ],
 )
 def test_set_doc_attribute(doc, expect, attr, value, test_transform):


### PR DESCRIPTION
There were some tests that weren't being run at all due to a missing call. This PR also adds it and fixes some issues that were uncovered.