### PR TITLE
Fix handling of indented HTML in DOMParser

### DIFF
--- a/prosemirror/model/from_dom.py
+++ b/prosemirror/model/from_dom.py
@@ -568,7 +568,7 @@ class ParseContext:
                     re.search(r"^[ \t\r\n\u000c]", value) is not None
                     and self.open == len(self.nodes) - 1
                 ):
-                    node_before = top.content[-1]
+                    node_before = top.content[-1] if top.content else None
                     dom_node_before = dom_.getprevious()
                     if (
                         node_before is None

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -179,6 +179,25 @@ def test_html_is_escaped():
             },
         ),
         (
+            "Indented HTML",
+            """
+            <div>
+                <p>
+                    test
+                </p>
+            </div>
+            """,
+            {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "test"}],
+                    },
+                ],
+            },
+        ),
+        (
             "Styled(marks) nodes pt1",
             """<div><p>test <strong>some bolded text</strong></p></div>""",
             {


### PR DESCRIPTION
This PR fixes a bug that causes `DOMParser` to throw an error when parsing indented HTML with the default collapsing of whitespace.

The root cause of the bug is in `add_text_node`. Notice the the assignment of `node_before` on line 571:

https://github.com/fellowapp/prosemirror-py/blob/34c961480a542dac93b380eaa6199224417d2b3f/prosemirror/model/from_dom.py#L571

When `top.content` is an empty list, the following error is thrown:

```
IndexError: list index out of range
```

Compare with [the JavaScript implementation of `addTextNode` in the original ProseMirror](https://github.com/ProseMirror/prosemirror-model/blob/be711f9c54143aa1965cdf51c091a1b2d8684e4b/src/from_dom.ts#L446):

```js
 let nodeBefore = top.content[top.content.length - 1]
```

Here, when `top.content` is an empty array, `nodeBefore` will be set  to `top.content[-1]`. In JavaScript, a negative indexing of an empty array will correctly return `undefined`. However, in Python, a negative indexing of an empty list will throw an error. Thus, we need to check if `top.content` is truthy before accessing `top.content[-1]`.

Thanks for the great library!